### PR TITLE
Fix: selectedTabUri にオプショナルチェーンを使用するように修正

### DIFF
--- a/app/src/views/Home.tsx
+++ b/app/src/views/Home.tsx
@@ -35,7 +35,7 @@ export const HomeView = (props: ScrollViewProps) => {
         [pinnedLists, client]
     )
 
-    const [selectedTabUri, setSelectedTabUri] = useState<string>(tabs[0].uri)
+    const [selectedTabUri, setSelectedTabUri] = useState<string>(tabs[0]?.uri ?? '')
 
     const [timelines, setTimelines] = useState<string[]>([])
     useEffect(() => {


### PR DESCRIPTION
## 問題
初回起動時などで `pinnedLists` が空の場合、`tabs[0]` が `undefined` になり、 `.uri` を読み込もうとしてクラッシュする。

## 解決方法
オプショナルチェーニング（`?.`）を追加して、`tabs` 配列が空の場合でも安全に処理できるようにしました。

## 変更内容
- `tabs[0].uri` → `tabs[0]?.uri ?? ''`