### PR TITLE
投稿作成画面において、プロフィールページへの投稿を除外する機能を追加しました。

### DIFF
--- a/app/src/components/Composer.tsx
+++ b/app/src/components/Composer.tsx
@@ -19,6 +19,7 @@ export const Composer = (props: Props) => {
     const { client } = useClient()
     const [willClose, setWillClose] = useState<boolean>(false)
     const [draft, setDraft] = useState<string>('')
+    const [postHome, setPostHome] = useState<boolean>(true)
 
     const theme = useTheme()
 
@@ -97,6 +98,8 @@ export const Composer = (props: Props) => {
                                     setSelected={props.setDestinations}
                                     keyFunc={(item: Timeline) => item.uri}
                                     labelFunc={(item: Timeline) => item.name}
+                                    postHome={postHome}
+                                    setPostHome={setPostHome}
                                 />
                             </div>
                             <div
@@ -131,6 +134,10 @@ export const Composer = (props: Props) => {
                                 <Button
                                     onClick={async () => {
                                         if (!client) return
+
+                                        const homeTimeline = `cckv://${client.ccid}/concrnt.world/main/home-timeline`
+                                        const memberOf = [...(postHome ? [homeTimeline] : []), ...props.destinations]
+
                                         const document = {
                                             key: '/concrnt.world/main/posts/{cdid}',
                                             schema: Schemas.markdownMessage,
@@ -138,10 +145,7 @@ export const Composer = (props: Props) => {
                                                 body: draft
                                             },
                                             author: client.ccid,
-                                            memberOf: [
-                                                `cckv://${client.ccid}/concrnt.world/main/home-timeline`,
-                                                ...props.destinations
-                                            ],
+                                            memberOf,
                                             createdAt: new Date()
                                         }
                                         client.api.commit(document).then(() => {

--- a/app/src/components/TimelinePicker.tsx
+++ b/app/src/components/TimelinePicker.tsx
@@ -7,16 +7,23 @@ import { MdOutlineTag } from 'react-icons/md'
 import { IoMdCloseCircle } from 'react-icons/io'
 import { IoMdAdd } from 'react-icons/io'
 
+import { useClient } from '../contexts/Client'
+import { Avatar } from '../ui/Avatar'
+
 interface Props {
     selected: string[]
     setSelected: (selected: string[]) => void
     items: any[]
     keyFunc: (item: any) => string
     labelFunc: (item: any) => string
+    postHome?: boolean
+    setPostHome?: (postHome: boolean) => void
 }
 
 export const TimelinePicker = (props: Props) => {
     const theme = useTheme()
+    const { client } = useClient()
+
     const [focused, setFocused] = useState(false)
     const [focusedIdx, setFocusedIdx] = useState<number>(0)
 
@@ -40,6 +47,37 @@ export const TimelinePicker = (props: Props) => {
                 alignItems: 'center'
             }}
         >
+            <Chip
+                headElement={
+                    <Avatar
+                        ccid={client?.ccid ?? ''}
+                        src={client?.user?.profile?.avatar}
+                        style={{
+                            width: 20,
+                            height: 20
+                        }}
+                    />
+                }
+                tailElement={
+                    <IoMdCloseCircle
+                        size={16}
+                        style={{
+                            transform: props.postHome === false ? 'rotate(45deg)' : 'none',
+                            transition: 'transform 0.2s'
+                        }}
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            props.setPostHome?.(!props.postHome)
+                        }}
+                    />
+                }
+                style={{
+                    textDecoration: props.postHome === false ? 'line-through' : 'none',
+                    opacity: props.postHome === false ? 0.5 : 1
+                }}
+            >
+                {client?.user?.profile?.username ?? 'Home'}
+            </Chip>
             {props.selected.map((sel) => {
                 const item = props.items.find((i) => props.keyFunc(i) === sel)
                 if (!item) return null


### PR DESCRIPTION
デフォルトでユーザーページにも投稿するやつを、
<img width="441" height="262" alt="Screenshot 2026-02-10 at 19 26 34" src="https://github.com/user-attachments/assets/154f77f8-a212-4d13-96be-36ba5c668702" />

↓こうする機能を実装しました。ユーザーページにも投稿されなくなることも確認済みです。
<img width="439" height="273" alt="Screenshot 2026-02-10 at 19 26 21" src="https://github.com/user-attachments/assets/58c6e110-1b34-40e2-9469-59def7995a80" />
