### PR TITLE
Android 端末における「戻る」操作に対応しました

### DIFF
--- a/app/src/views/Main.tsx
+++ b/app/src/views/Main.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { TabLayout } from '../layouts/Tab'
 import { SidebarLayout } from '../layouts/Sidebar'
 import { Sidebar } from '../components/Sidebar'
@@ -117,6 +117,24 @@ export const MainView = () => {
         },
         [selectedTab]
     )
+
+    // Android back button handling
+    useEffect(() => {
+        ;(window as any).__concrntHandleBack = (): boolean => {
+            const stackRef = stackRefs.current[selectedTab]
+            if (stackRef && stackRef.pop()) {
+                return true
+            }
+            if (selectedTab !== 'home') {
+                setSelectedTab('home')
+                return true
+            }
+            return false
+        }
+        return () => {
+            delete (window as any).__concrntHandleBack
+        }
+    }, [selectedTab])
 
     return (
         <>

--- a/src-tauri/gen/android/app/src/main/java/world/concrnt/app/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/world/concrnt/app/MainActivity.kt
@@ -1,11 +1,37 @@
 package world.concrnt.app
 
 import android.os.Bundle
+import android.webkit.WebView
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 
 class MainActivity : TauriActivity() {
+  private var webView: WebView? = null
+
   override fun onCreate(savedInstanceState: Bundle?) {
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)
+
+    onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+      override fun handleOnBackPressed() {
+        val wv = webView
+        if (wv != null) {
+          wv.evaluateJavascript(
+            "(function() { return window.__concrntHandleBack ? window.__concrntHandleBack() : false; })()"
+          ) { result ->
+            if (result == "false" || result == "null" || result == "undefined") {
+              finish()
+            }
+          }
+        } else {
+          finish()
+        }
+      }
+    })
+  }
+
+  override fun onWebViewCreate(webView: WebView) {
+    super.onWebViewCreate(webView)
+    this.webView = webView
   }
 }


### PR DESCRIPTION
fix #9 

Android 端末で「戻る」操作をした際に、即座にアプリが終了してしまう問題に対応しました。

【修正内容】
`MainActivity.kt`
- `OnBackPressedCallback` を登録し、戻る操作を `evaluateJavascript` 経由でフロントエンド側にブリッジするようにしました。

`app/src/views/Main.tsx`
- `window.__concrntHandleBack` をグローバル関数として登録し、以下の優先順位で処理するようにしました:
1. アクティブなタブの `StackLayout` にスタックがあれば pop
2. スタックが空でホーム以外のタブにいる場合はホームタブに戻る
3. ホームタブかつスタックが空の場合はアプリを終了する