### PR TITLE
プロフィールのアイコン設定で画像をクロップする機能を追加

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "motion": "^12.36.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-easy-crop": "^5.5.7",
     "react-error-boundary": "^6.0.3",
     "react-icons": "^5.5.0",
     "react-syntax-highlighter": "^16.1.0",

--- a/app/src/components/ImageCropper.tsx
+++ b/app/src/components/ImageCropper.tsx
@@ -1,0 +1,123 @@
+import { useState, useCallback } from 'react'
+import Cropper, { type Area } from 'react-easy-crop'
+import { CssVar } from '../types/Theme'
+import { cropImage } from '../utils/cropImage'
+
+interface Props {
+    imageSrc: string
+    onComplete: (croppedFile: File) => void
+    onCancel: () => void
+    /** 出力画像の一辺のサイズ (px)。デフォルト 512 */
+    outputSize?: number
+}
+
+export const ImageCropper = (props: Props) => {
+    const { imageSrc, onComplete, onCancel, outputSize = 512 } = props
+
+    const [crop, setCrop] = useState({ x: 0, y: 0 })
+    const [zoom, setZoom] = useState(1)
+    const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null)
+    const [processing, setProcessing] = useState(false)
+
+    const onCropComplete = useCallback((_croppedArea: Area, croppedAreaPixels: Area) => {
+        setCroppedAreaPixels(croppedAreaPixels)
+    }, [])
+
+    const handleConfirm = useCallback(async () => {
+        if (!croppedAreaPixels) return
+        setProcessing(true)
+        try {
+            const croppedFile = await cropImage(imageSrc, croppedAreaPixels, outputSize)
+            onComplete(croppedFile)
+        } catch (e) {
+            console.error('Failed to crop image:', e)
+        } finally {
+            setProcessing(false)
+        }
+    }, [croppedAreaPixels, imageSrc, onComplete, outputSize])
+
+    return (
+        <div
+            style={{
+                position: 'fixed',
+                top: 0,
+                left: 0,
+                width: '100vw',
+                height: '100dvh',
+                backgroundColor: 'rgba(0, 0, 0, 0.95)',
+                zIndex: 10000,
+                display: 'flex',
+                flexDirection: 'column',
+                touchAction: 'none'
+            }}
+        >
+            {/* クロッパー領域 */}
+            <div
+                style={{
+                    position: 'relative',
+                    flex: 1,
+                    marginTop: 'env(safe-area-inset-top)'
+                }}
+            >
+                <Cropper
+                    image={imageSrc}
+                    crop={crop}
+                    zoom={zoom}
+                    aspect={1}
+                    onCropChange={setCrop}
+                    onZoomChange={setZoom}
+                    onCropComplete={onCropComplete}
+                    cropShape="rect"
+                    showGrid={false}
+                    style={{
+                        cropAreaStyle: {
+                            borderRadius: '8px'
+                        }
+                    }}
+                />
+            </div>
+
+            {/* 下部コントロール */}
+            <div
+                style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    padding: `${CssVar.space(4)} ${CssVar.space(6)}`,
+                    paddingBottom: `max(${CssVar.space(4)}, env(safe-area-inset-bottom))`
+                }}
+            >
+                <button
+                    onClick={onCancel}
+                    style={{
+                        background: 'none',
+                        border: 'none',
+                        color: 'white',
+                        fontSize: '16px',
+                        cursor: 'pointer',
+                        padding: `${CssVar.space(2)} ${CssVar.space(4)}`
+                    }}
+                >
+                    キャンセル
+                </button>
+                <button
+                    onClick={handleConfirm}
+                    disabled={processing}
+                    style={{
+                        background: 'white',
+                        border: 'none',
+                        color: 'black',
+                        fontSize: '16px',
+                        fontWeight: 'bold',
+                        cursor: processing ? 'default' : 'pointer',
+                        padding: `${CssVar.space(2)} ${CssVar.space(4)}`,
+                        borderRadius: CssVar.round(1),
+                        opacity: processing ? 0.5 : 1
+                    }}
+                >
+                    {processing ? '処理中...' : '決定'}
+                </button>
+            </div>
+        </div>
+    )
+}

--- a/app/src/components/ProfileEditor.tsx
+++ b/app/src/components/ProfileEditor.tsx
@@ -1,8 +1,10 @@
 import { useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Avatar, Button, CCWallpaper, Text, TextField } from '@concrnt/ui'
 import { useClient } from '../contexts/Client'
 import { CssVar } from '../types/Theme'
 import { uploadImage } from '../utils/uploadImage'
+import { ImageCropper } from './ImageCropper'
 
 interface Props {
     onComplete?: () => void
@@ -24,6 +26,7 @@ export const ProfileEditor = (props: Props) => {
     const bannerInputRef = useRef<HTMLInputElement>(null)
 
     const [saving, setSaving] = useState<boolean>(false)
+    const [cropperSrc, setCropperSrc] = useState<string | null>(null)
 
     return (
         <div
@@ -98,15 +101,35 @@ export const ProfileEditor = (props: Props) => {
                 onChange={(e) => {
                     if (e.target.files?.[0]) {
                         const file = e.target.files[0]
-                        setAvatarDraft(file)
                         const reader = new FileReader()
                         reader.onload = (event) => {
-                            setAvatar(event.target?.result as string)
+                            setCropperSrc(event.target?.result as string)
                         }
                         reader.readAsDataURL(file)
+                        // 同じファイルを再選択できるようにリセット
+                        if (avatarInputRef.current) {
+                            avatarInputRef.current.value = ''
+                        }
                     }
                 }}
             />
+
+            {/* アバタークロッパー — Drawer の上に表示するため createPortal を使用 */}
+            {cropperSrc &&
+                createPortal(
+                    <ImageCropper
+                        imageSrc={cropperSrc}
+                        onComplete={(croppedFile) => {
+                            setAvatarDraft(croppedFile)
+                            setAvatar(URL.createObjectURL(croppedFile))
+                            setCropperSrc(null)
+                        }}
+                        onCancel={() => {
+                            setCropperSrc(null)
+                        }}
+                    />,
+                    document.body
+                )}
 
             <input
                 hidden

--- a/app/src/utils/cropImage.ts
+++ b/app/src/utils/cropImage.ts
@@ -1,0 +1,42 @@
+const createImage = (url: string): Promise<HTMLImageElement> =>
+    new Promise((resolve, reject) => {
+        const image = new Image()
+        image.addEventListener('load', () => resolve(image))
+        image.addEventListener('error', (error) => reject(error))
+        image.crossOrigin = 'anonymous'
+        image.src = url
+    })
+
+interface PixelCrop {
+    x: number
+    y: number
+    width: number
+    height: number
+}
+
+/**
+ * 指定されたクロップ領域で画像を切り抜き、outputSize x outputSize の正方形 PNG File を返す
+ */
+export const cropImage = async (imageSrc: string, pixelCrop: PixelCrop, outputSize: number = 512): Promise<File> => {
+    const image = await createImage(imageSrc)
+    const canvas = document.createElement('canvas')
+    canvas.width = outputSize
+    canvas.height = outputSize
+    const ctx = canvas.getContext('2d')
+
+    if (!ctx) {
+        throw new Error('Failed to get canvas context')
+    }
+
+    ctx.drawImage(image, pixelCrop.x, pixelCrop.y, pixelCrop.width, pixelCrop.height, 0, 0, outputSize, outputSize)
+
+    return new Promise((resolve, reject) => {
+        canvas.toBlob((blob) => {
+            if (!blob) {
+                reject(new Error('Failed to create blob'))
+                return
+            }
+            resolve(new File([blob], 'avatar.png', { type: 'image/png' }))
+        }, 'image/png')
+    })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-easy-crop:
+        specifier: ^5.5.7
+        version: 5.5.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-error-boundary:
         specifier: ^6.0.3
         version: 6.1.1(react@19.2.4)
@@ -2237,6 +2240,9 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
+  normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2381,6 +2387,12 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-easy-crop@5.5.7:
+    resolution: {integrity: sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
 
   react-error-boundary@6.1.1:
     resolution: {integrity: sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==}
@@ -4897,6 +4909,8 @@ snapshots:
 
   node-releases@2.0.36: {}
 
+  normalize-wheel@1.0.1: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -5061,6 +5075,13 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-easy-crop@5.5.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
 
   react-error-boundary@6.1.1(react@19.2.4):
     dependencies:


### PR DESCRIPTION
resolve #33

# プロフィールのアバター設定に画像クロップ機能を追加

## 概要

プロフィール編集画面のアバター画像設定時に、正方形にクロップできるUIを追加しました。

## 変更内容

### 新規ファイル
- **`app/src/components/ImageCropper.tsx`** — フルスクリーンの画像クロッパーコンポーネント
  - `react-easy-crop` を使用（ピンチズーム・ドラッグ対応）
  - 正方形 (aspect 1:1) のクロップ領域
  - 「キャンセル」「決定」ボタン
  - `createPortal` で Drawer の上にオーバーレイ表示
- **`app/src/utils/cropImage.ts`** — Canvas API でクロップ領域を切り出し、512×512 の PNG `File` を返すユーティリティ

### 変更ファイル
- **`app/src/components/ProfileEditor.tsx`** — アバター選択フローにクロッパーを統合
  - ファイル選択 → クロッパー表示 → クロップ完了後にプレビュー＆draft セット

### 依存関係
- `react-easy-crop` を追加

## 動作フロー

1. Avatar をタップ → ファイル選択
2. 画像選択後、フルスクリーンのクロッパーが表示されます
3. ドラッグ・ピンチズームで位置とサイズを調整できます。今のところ回転はできません
4. 「決定」→ 512×512 にクロップされた画像がプレビューに反映されます
5. 「保存」でアップロードされます
<img width="1080" height="2424" alt="Screenshot_20260414-202259" src="https://github.com/user-attachments/assets/3a86f5c4-5b05-41a9-9db1-6c5b85e9af71" />

<img width="1080" height="2424" alt="Screenshot_20260414-202309" src="https://github.com/user-attachments/assets/fbf45a98-540d-411b-becf-88ce7b219e63" />
