### PR TITLE
フォロー、フォロワー数の表示とフォロー(連絡先)一覧を実装しました

### DIFF
--- a/app/src/components/AcknowledgeButton.tsx
+++ b/app/src/components/AcknowledgeButton.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import { Button } from '@concrnt/ui'
+import { useClient } from '../contexts/Client'
+
+interface Props {
+    ccid: string
+    onChange?: () => void
+}
+
+export const AcknowledgeButton = (props: Props) => {
+    const { client } = useClient()
+
+    const [acknowledged, setAcknowledged] = useState<boolean>(() => {
+        return !!client?.acknowledging.find((a) => a.associate === `cckv://${props.ccid}`)
+    })
+
+    if (!client || client.ccid === props.ccid) return null
+
+    const handleClick = async () => {
+        if (acknowledged) {
+            await client.UnAcknowledge(props.ccid)
+            setAcknowledged(false)
+        } else {
+            await client.Acknowledge(props.ccid)
+            setAcknowledged(true)
+        }
+        props.onChange?.()
+    }
+
+    return (
+        <Button variant={acknowledged ? 'outlined' : 'contained'} onClick={handleClick}>
+            {acknowledged ? 'フォロー中' : 'フォロー'}
+        </Button>
+    )
+}

--- a/app/src/components/AcknowledgeList.tsx
+++ b/app/src/components/AcknowledgeList.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
+import { Suspense, use, useMemo, useState } from 'react'
 import { Avatar, Tab, Tabs, Text } from '@concrnt/ui'
-import { User } from '@concrnt/worldlib'
+import { isNonNullOrUndefined, User } from '@concrnt/worldlib'
 import { useClient } from '../contexts/Client'
 import { CssVar } from '../types/Theme'
 import { AcknowledgeButton } from './AcknowledgeButton'
@@ -14,43 +14,35 @@ interface Props {
 
 export const AcknowledgeList = (props: Props) => {
     const { client } = useClient()
-    const stack = useStack()
 
     const [tab, setTab] = useState<'acknowledging' | 'acknowledgers'>(props.initialTab ?? 'acknowledging')
 
-    const [acknowledgingUsers, setAcknowledgingUsers] = useState<User[] | null>(null)
-    const [acknowledgersUsers, setAcknowledgersUsers] = useState<User[] | null>(null)
-
-    useEffect(() => {
-        let unmounted = false
-        if (!client) return
-
-        // Acknowledging: acks[i].associate === 'cckv://${対象ccid}' → ccidを抽出
-        client.getAcknowledging(props.targetCcid).then(async (acks) => {
-            const ccids = acks.map((a) => a.associate.replace('cckv://', ''))
+    // TODO: ユーザーへの変換はリスト上の個々のコンポーネントで行う
+    const acknowledgingUsersPromise = useMemo(() => {
+        if (!client) return Promise.resolve(null)
+        return client.getAcknowledging(props.targetCcid).then(async (acks) => {
+            const ccids = acks
+                .map((a) => a.associate)
+                .filter(isNonNullOrUndefined)
+                .map((uri) => uri.replace('cckv://', ''))
             const users = await Promise.all(ccids.map((ccid) => client.getUser(ccid)))
-            if (unmounted) return
-            setAcknowledgingUsers(users.filter((u): u is User => u !== null))
+            return users.filter((u): u is User => u !== null)
         })
-
-        // Acknowledgers: acks[i].author がフォロワーのccid
-        client.getAcknowledgers(props.targetCcid).then(async (acks) => {
-            const ccids = acks.map((a) => a.author)
-            const users = await Promise.all(ccids.map((ccid) => client.getUser(ccid)))
-            if (unmounted) return
-            setAcknowledgersUsers(users.filter((u): u is User => u !== null))
-        })
-
-        return () => {
-            unmounted = true
-        }
     }, [client, props.targetCcid])
 
-    const users = tab === 'acknowledging' ? acknowledgingUsers : acknowledgersUsers
+    const acknowledgersUsersPromise = useMemo(() => {
+        if (!client) return Promise.resolve(null)
+        return client.getAcknowledgers(props.targetCcid).then(async (acks) => {
+            const ccids = acks
+                .map((a) => a.associate)
+                .filter(isNonNullOrUndefined)
+                .map((uri) => uri.replace('cckv://', ''))
+            const users = await Promise.all(ccids.map((ccid) => client.getUser(ccid)))
+            return users.filter((u): u is User => u !== null)
+        })
+    }, [client, props.targetCcid])
 
-    const openProfile = (ccid: string) => {
-        stack.push(<ProfileView id={ccid} />)
-    }
+    const users = tab === 'acknowledging' ? acknowledgingUsersPromise : acknowledgersUsersPromise
 
     return (
         <div
@@ -79,75 +71,98 @@ export const AcknowledgeList = (props: Props) => {
                     フォロワー
                 </Tab>
             </Tabs>
-            <div
-                style={{
-                    flex: 1,
-                    overflowY: 'auto',
-                    padding: CssVar.space(2)
-                }}
+            <Suspense
+                key={tab + props.targetCcid}
+                fallback={
+                    <div style={{ padding: CssVar.space(2) }}>
+                        <Text variant="caption">Loading...</Text>
+                    </div>
+                }
             >
-                {users === null ? (
-                    <Text variant="caption">Loading...</Text>
-                ) : users.length === 0 ? (
-                    <Text variant="caption">No users</Text>
-                ) : (
-                    <div
-                        style={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: CssVar.space(2)
-                        }}
-                    >
-                        {users.map((user) => (
+                <UserList usersPromise={users} />
+            </Suspense>
+        </div>
+    )
+}
+
+const UserList = (props: { usersPromise: Promise<User[] | null> }) => {
+    const stack = useStack()
+    const openProfile = (ccid: string) => {
+        stack.push(<ProfileView id={ccid} />)
+    }
+
+    const users = use(props.usersPromise)
+
+    // TODO: ユーザーの表示をコンポーネント化する
+    return (
+        <div
+            style={{
+                flex: 1,
+                overflowY: 'auto',
+                padding: CssVar.space(2)
+            }}
+        >
+            {users === null ? (
+                <Text variant="caption">Loading...</Text>
+            ) : users.length === 0 ? (
+                <Text variant="caption">No users</Text>
+            ) : (
+                <div
+                    style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: CssVar.space(2)
+                    }}
+                >
+                    {users.map((user) => (
+                        <div
+                            key={user.ccid}
+                            style={{
+                                display: 'flex',
+                                alignItems: 'flex-start',
+                                gap: CssVar.space(1)
+                            }}
+                        >
+                            <Avatar
+                                ccid={user.ccid}
+                                src={user.profile?.avatar}
+                                style={{
+                                    width: '48px',
+                                    height: '48px',
+                                    cursor: 'pointer',
+                                    flexShrink: 0
+                                }}
+                                onClick={() => openProfile(user.ccid)}
+                            />
                             <div
-                                key={user.ccid}
                                 style={{
                                     display: 'flex',
-                                    alignItems: 'flex-start',
-                                    gap: CssVar.space(1)
+                                    flexDirection: 'column',
+                                    flex: 1,
+                                    minWidth: 0,
+                                    cursor: 'pointer'
                                 }}
+                                onClick={() => openProfile(user.ccid)}
                             >
-                                <Avatar
-                                    ccid={user.ccid}
-                                    src={user.profile?.avatar}
+                                <Text variant="h6">{user.profile?.username || 'anonymous'}</Text>
+                                <Text
+                                    variant="caption"
                                     style={{
-                                        width: '48px',
-                                        height: '48px',
-                                        cursor: 'pointer',
-                                        flexShrink: 0
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        display: '-webkit-box',
+                                        WebkitLineClamp: 2,
+                                        WebkitBoxOrient: 'vertical'
                                     }}
-                                    onClick={() => openProfile(user.ccid)}
-                                />
-                                <div
-                                    style={{
-                                        display: 'flex',
-                                        flexDirection: 'column',
-                                        flex: 1,
-                                        minWidth: 0,
-                                        cursor: 'pointer'
-                                    }}
-                                    onClick={() => openProfile(user.ccid)}
                                 >
-                                    <Text variant="h6">{user.profile?.username || 'anonymous'}</Text>
-                                    <Text
-                                        variant="caption"
-                                        style={{
-                                            overflow: 'hidden',
-                                            textOverflow: 'ellipsis',
-                                            display: '-webkit-box',
-                                            WebkitLineClamp: 2,
-                                            WebkitBoxOrient: 'vertical'
-                                        }}
-                                    >
-                                        {user.profile?.description || ''}
-                                    </Text>
-                                </div>
-                                <AcknowledgeButton ccid={user.ccid} />
+                                    {user.profile?.description || ''}
+                                </Text>
                             </div>
-                        ))}
-                    </div>
-                )}
-            </div>
+                            <AcknowledgeButton ccid={user.ccid} />
+                        </div>
+                    ))}
+                </div>
+            )}
         </div>
     )
 }

--- a/app/src/components/AcknowledgeList.tsx
+++ b/app/src/components/AcknowledgeList.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from 'react'
+import { Avatar, Tab, Tabs, Text } from '@concrnt/ui'
+import { User } from '@concrnt/worldlib'
+import { useClient } from '../contexts/Client'
+import { CssVar } from '../types/Theme'
+import { AcknowledgeButton } from './AcknowledgeButton'
+import { useStack } from '../layouts/Stack'
+import { ProfileView } from '../views/Profile'
+
+interface Props {
+    targetCcid: string
+    initialTab?: 'acknowledging' | 'acknowledgers'
+}
+
+export const AcknowledgeList = (props: Props) => {
+    const { client } = useClient()
+    const stack = useStack()
+
+    const [tab, setTab] = useState<'acknowledging' | 'acknowledgers'>(props.initialTab ?? 'acknowledging')
+
+    const [acknowledgingUsers, setAcknowledgingUsers] = useState<User[] | null>(null)
+    const [acknowledgersUsers, setAcknowledgersUsers] = useState<User[] | null>(null)
+
+    useEffect(() => {
+        let unmounted = false
+        if (!client) return
+
+        // Acknowledging: acks[i].associate === 'cckv://${対象ccid}' → ccidを抽出
+        client.getAcknowledging(props.targetCcid).then(async (acks) => {
+            const ccids = acks.map((a) => a.associate.replace('cckv://', ''))
+            const users = await Promise.all(ccids.map((ccid) => client.getUser(ccid)))
+            if (unmounted) return
+            setAcknowledgingUsers(users.filter((u): u is User => u !== null))
+        })
+
+        // Acknowledgers: acks[i].author がフォロワーのccid
+        client.getAcknowledgers(props.targetCcid).then(async (acks) => {
+            const ccids = acks.map((a) => a.author)
+            const users = await Promise.all(ccids.map((ccid) => client.getUser(ccid)))
+            if (unmounted) return
+            setAcknowledgersUsers(users.filter((u): u is User => u !== null))
+        })
+
+        return () => {
+            unmounted = true
+        }
+    }, [client, props.targetCcid])
+
+    const users = tab === 'acknowledging' ? acknowledgingUsers : acknowledgersUsers
+
+    const openProfile = (ccid: string) => {
+        stack.push(<ProfileView id={ccid} />)
+    }
+
+    return (
+        <div
+            style={{
+                display: 'flex',
+                flexDirection: 'column',
+                flex: 1,
+                overflow: 'hidden'
+            }}
+        >
+            <Tabs>
+                <Tab
+                    selected={tab === 'acknowledging'}
+                    onClick={() => setTab('acknowledging')}
+                    groupId="acknowledge-list-tabs"
+                    style={{ color: CssVar.contentText }}
+                >
+                    フォロー
+                </Tab>
+                <Tab
+                    selected={tab === 'acknowledgers'}
+                    onClick={() => setTab('acknowledgers')}
+                    groupId="acknowledge-list-tabs"
+                    style={{ color: CssVar.contentText }}
+                >
+                    フォロワー
+                </Tab>
+            </Tabs>
+            <div
+                style={{
+                    flex: 1,
+                    overflowY: 'auto',
+                    padding: CssVar.space(2)
+                }}
+            >
+                {users === null ? (
+                    <Text variant="caption">Loading...</Text>
+                ) : users.length === 0 ? (
+                    <Text variant="caption">No users</Text>
+                ) : (
+                    <div
+                        style={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: CssVar.space(2)
+                        }}
+                    >
+                        {users.map((user) => (
+                            <div
+                                key={user.ccid}
+                                style={{
+                                    display: 'flex',
+                                    alignItems: 'flex-start',
+                                    gap: CssVar.space(1)
+                                }}
+                            >
+                                <Avatar
+                                    ccid={user.ccid}
+                                    src={user.profile?.avatar}
+                                    style={{
+                                        width: '48px',
+                                        height: '48px',
+                                        cursor: 'pointer',
+                                        flexShrink: 0
+                                    }}
+                                    onClick={() => openProfile(user.ccid)}
+                                />
+                                <div
+                                    style={{
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        flex: 1,
+                                        minWidth: 0,
+                                        cursor: 'pointer'
+                                    }}
+                                    onClick={() => openProfile(user.ccid)}
+                                >
+                                    <Text variant="h6">{user.profile?.username || 'anonymous'}</Text>
+                                    <Text
+                                        variant="caption"
+                                        style={{
+                                            overflow: 'hidden',
+                                            textOverflow: 'ellipsis',
+                                            display: '-webkit-box',
+                                            WebkitLineClamp: 2,
+                                            WebkitBoxOrient: 'vertical'
+                                        }}
+                                    >
+                                        {user.profile?.description || ''}
+                                    </Text>
+                                </div>
+                                <AcknowledgeButton ccid={user.ccid} />
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/app/src/components/AcknowledgeList.tsx
+++ b/app/src/components/AcknowledgeList.tsx
@@ -33,10 +33,7 @@ export const AcknowledgeList = (props: Props) => {
     const acknowledgersUsersPromise = useMemo(() => {
         if (!client) return Promise.resolve(null)
         return client.getAcknowledgers(props.targetCcid).then(async (acks) => {
-            const ccids = acks
-                .map((a) => a.associate)
-                .filter(isNonNullOrUndefined)
-                .map((uri) => uri.replace('cckv://', ''))
+            const ccids = acks.map((a) => a.author)
             const users = await Promise.all(ccids.map((ccid) => client.getUser(ccid)))
             return users.filter((u): u is User => u !== null)
         })

--- a/app/src/contexts/Drawer.tsx
+++ b/app/src/contexts/Drawer.tsx
@@ -1,7 +1,8 @@
 import { AnimatePresence, motion, useDragControls, useMotionValue, useTransform } from 'motion/react'
-import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react'
+import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { animate } from 'motion'
 import { CssVar } from '../types/Theme'
+import { StackLayout, type StackLayoutRef } from '../layouts/Stack'
 
 interface DrawerContextState {
     open: (content: ReactNode) => void
@@ -37,6 +38,26 @@ export const DrawerProvider = (props: Props) => {
     const close = useCallback(() => {
         setContent(null)
     }, [])
+
+    const stackRef = useRef<StackLayoutRef | null>(null)
+
+    // ドロワーが開いている間はAndroidバックボタンを横取りし、
+    // ドロワー内Stackのpop→ドロワーを閉じるの優先順で処理する
+    useEffect(() => {
+        if (!content) return
+
+        const prev = (window as any).__concrntHandleBack
+        ;(window as any).__concrntHandleBack = (): boolean => {
+            if (stackRef.current?.pop()) {
+                return true
+            }
+            close()
+            return true
+        }
+        return () => {
+            ;(window as any).__concrntHandleBack = prev
+        }
+    }, [content, close])
 
     const value = useMemo(
         () => ({
@@ -74,7 +95,9 @@ export const DrawerProvider = (props: Props) => {
                                 paddingBottom: 'env(safe-area-inset-bottom)',
                                 borderRadius: `${CssVar.round(1)} ${CssVar.round(1)} 0 0`,
                                 height,
-                                y
+                                y,
+                                display: 'flex',
+                                flexDirection: 'column'
                             }}
                             drag="y"
                             dragControls={dragControls}
@@ -121,12 +144,12 @@ export const DrawerProvider = (props: Props) => {
                                     dragControls.start(e)
                                 }}
                             >
-                                {/* ハンドルの見た目は変えず、当たり判定を縦方向に拡張する透明レイヤー */}
+                                {/* ハンドルの見た目は変えず、当たり判定を縦方向に拡張する透明レイヤー (上40px / 下8px) */}
                                 <div
                                     style={{
                                         position: 'absolute',
-                                        top: `-${CssVar.space(3)}`,
-                                        bottom: `-${CssVar.space(3)}`,
+                                        top: `-${CssVar.space(7)}`,
+                                        bottom: CssVar.space(1),
                                         left: 0,
                                         right: 0
                                     }}
@@ -143,11 +166,12 @@ export const DrawerProvider = (props: Props) => {
                             <div
                                 style={{
                                     padding: `0 ${CssVar.space(4)}`,
-                                    overflow: 'auto',
-                                    flex: 1
+                                    flex: 1,
+                                    display: 'flex',
+                                    minHeight: 0
                                 }}
                             >
-                                {content}
+                                <StackLayout ref={stackRef}>{content}</StackLayout>
                             </div>
                         </motion.div>
                     </>

--- a/app/src/contexts/Drawer.tsx
+++ b/app/src/contexts/Drawer.tsx
@@ -114,12 +114,23 @@ export const DrawerProvider = (props: Props) => {
                                 style={{
                                     display: 'flex',
                                     justifyContent: 'center',
-                                    padding: `${CssVar.space(3)} 0`
+                                    padding: `${CssVar.space(3)} 0`,
+                                    position: 'relative'
                                 }}
                                 onPointerDown={(e) => {
                                     dragControls.start(e)
                                 }}
                             >
+                                {/* ハンドルの見た目は変えず、当たり判定を縦方向に拡張する透明レイヤー */}
+                                <div
+                                    style={{
+                                        position: 'absolute',
+                                        top: `-${CssVar.space(3)}`,
+                                        bottom: `-${CssVar.space(3)}`,
+                                        left: 0,
+                                        right: 0
+                                    }}
+                                />
                                 <div
                                     style={{
                                         width: '30px',

--- a/app/src/views/Contacts.tsx
+++ b/app/src/views/Contacts.tsx
@@ -1,10 +1,15 @@
 import { View } from '@concrnt/ui'
 import { Header } from '../ui/Header'
+import { useClient } from '../contexts/Client'
+import { AcknowledgeList } from '../components/AcknowledgeList'
 
 export const ContactsView = () => {
+    const { client } = useClient()
+
     return (
         <View>
             <Header>Contacts</Header>
+            {client && <AcknowledgeList targetCcid={client.ccid} />}
         </View>
     )
 }

--- a/app/src/views/Profile.tsx
+++ b/app/src/views/Profile.tsx
@@ -34,12 +34,13 @@ export const ProfileView = (props: Props) => {
         return client?.ccid === props.id
     }, [client, props.id])
 
+    const [updateStats, setUpdateStats] = useState(0)
     const statsPromise = useMemo(() => {
         return profilePromise.then((user) => {
             if (!user) return { acknowledging: 0, acknowledged: 0 }
             return user.GetStats(client!)
         })
-    }, [client, profilePromise])
+    }, [client, profilePromise, updateStats])
 
     const [tab, setTab] = useState<'posts' | 'media' | 'activity'>('posts')
 
@@ -149,7 +150,7 @@ export const ProfileView = (props: Props) => {
                                         Edit Profile
                                     </Button>
                                 ) : (
-                                    <AcknowledgeButton ccid={props.id} /*onChange={refetchStats}*/ />
+                                    <AcknowledgeButton ccid={props.id} onChange={() => setUpdateStats((s) => s + 1)} />
                                 )}
                             </div>
                             <div>

--- a/app/src/views/Profile.tsx
+++ b/app/src/views/Profile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Avatar, CCWallpaper, IconButton, Text, View, Button, Tabs, Tab, Divider, useTheme } from '@concrnt/ui'
 import { useClient } from '../contexts/Client'
 
@@ -34,32 +34,11 @@ export const ProfileView = (props: Props) => {
         return client?.ccid === props.id
     }, [client, props.id])
 
-    const [stats, setStats] = useState<{ acknowledging: number; acknowledged: number }>({
-        acknowledging: 0,
-        acknowledged: 0
-    })
-
-    const refetchStats = async () => {
-        if (!client) return
-        const user = await profilePromise
-        if (!user) return
-        const newStats = await user.GetStats(client)
-        setStats(newStats)
-    }
-
-    useEffect(() => {
-        let unmounted = false
-        if (!client) return
-        profilePromise.then((user) => {
-            if (!user) return
-            user.GetStats(client).then((s) => {
-                if (unmounted) return
-                setStats(s)
-            })
+    const statsPromise = useMemo(() => {
+        return profilePromise.then((user) => {
+            if (!user) return { acknowledging: 0, acknowledged: 0 }
+            return user.GetStats(client!)
         })
-        return () => {
-            unmounted = true
-        }
     }, [client, profilePromise])
 
     const [tab, setTab] = useState<'posts' | 'media' | 'activity'>('posts')
@@ -170,7 +149,7 @@ export const ProfileView = (props: Props) => {
                                         Edit Profile
                                     </Button>
                                 ) : (
-                                    <AcknowledgeButton ccid={props.id} onChange={refetchStats} />
+                                    <AcknowledgeButton ccid={props.id} /*onChange={refetchStats}*/ />
                                 )}
                             </div>
                             <div>
@@ -209,7 +188,7 @@ export const ProfileView = (props: Props) => {
                                         )
                                     }
                                 >
-                                    <Text>{`${stats.acknowledging} フォロー`}</Text>
+                                    <Text>{statsPromise.then((s) => `${s.acknowledging} フォロー`)}</Text>
                                 </div>
                                 <div
                                     style={{ cursor: 'pointer' }}
@@ -219,7 +198,7 @@ export const ProfileView = (props: Props) => {
                                         )
                                     }
                                 >
-                                    <Text>{`${stats.acknowledged} フォロワー`}</Text>
+                                    <Text>{statsPromise.then((s) => `${s.acknowledged} フォロワー`)}</Text>
                                 </div>
                             </div>
                         </div>

--- a/app/src/views/Profile.tsx
+++ b/app/src/views/Profile.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Avatar, CCWallpaper, IconButton, Text, View, Button, Tabs, Tab, Divider, useTheme } from '@concrnt/ui'
 import { useClient } from '../contexts/Client'
 
@@ -11,6 +11,8 @@ import { useNavigation } from '../contexts/Navigation'
 import { QueryTimeline } from '../components/QueryTimeline'
 import { Schemas } from '@concrnt/worldlib'
 import { CssVar } from '../types/Theme'
+import { AcknowledgeButton } from '../components/AcknowledgeButton'
+import { AcknowledgeList } from '../components/AcknowledgeList'
 
 interface Props {
     id: string
@@ -28,14 +30,37 @@ export const ProfileView = (props: Props) => {
         return client!.getUser(props.id).catch(() => null)
     }, [client, props.id])
 
-    const myAck = useMemo(() => {
-        if (!client) return null
-        return client.acknowledging.find((a: any) => a.associate === `cckv://${props.id}`)
-    }, [client, props.id])
-
     const isMe = useMemo(() => {
         return client?.ccid === props.id
     }, [client, props.id])
+
+    const [stats, setStats] = useState<{ acknowledging: number; acknowledged: number }>({
+        acknowledging: 0,
+        acknowledged: 0
+    })
+
+    const refetchStats = async () => {
+        if (!client) return
+        const user = await profilePromise
+        if (!user) return
+        const newStats = await user.GetStats(client)
+        setStats(newStats)
+    }
+
+    useEffect(() => {
+        let unmounted = false
+        if (!client) return
+        profilePromise.then((user) => {
+            if (!user) return
+            user.GetStats(client).then((s) => {
+                if (unmounted) return
+                setStats(s)
+            })
+        })
+        return () => {
+            unmounted = true
+        }
+    }, [client, profilePromise])
 
     const [tab, setTab] = useState<'posts' | 'media' | 'activity'>('posts')
 
@@ -144,28 +169,8 @@ export const ProfileView = (props: Props) => {
                                     >
                                         Edit Profile
                                     </Button>
-                                ) : myAck ? (
-                                    <Button
-                                        onClick={() => {
-                                            if (!client) return
-                                            client.UnAcknowledge(props.id).then((e) => {
-                                                console.log('Unacknowledged', e)
-                                            })
-                                        }}
-                                    >
-                                        Acknowledged
-                                    </Button>
                                 ) : (
-                                    <Button
-                                        onClick={() => {
-                                            if (!client) return
-                                            client.Acknowledge(props.id).then((e) => {
-                                                console.log('Acknowledged', e)
-                                            })
-                                        }}
-                                    >
-                                        Acknowledge
-                                    </Button>
+                                    <AcknowledgeButton ccid={props.id} onChange={refetchStats} />
                                 )}
                             </div>
                             <div>
@@ -189,6 +194,33 @@ export const ProfileView = (props: Props) => {
                                         (user) => user?.profile?.description || '説明はまだありません'
                                     )}
                                 </Text>
+                            </div>
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    gap: CssVar.space(2)
+                                }}
+                            >
+                                <div
+                                    style={{ cursor: 'pointer' }}
+                                    onClick={() =>
+                                        drawer.open(
+                                            <AcknowledgeList targetCcid={props.id} initialTab="acknowledging" />
+                                        )
+                                    }
+                                >
+                                    <Text>{`${stats.acknowledging} フォロー`}</Text>
+                                </div>
+                                <div
+                                    style={{ cursor: 'pointer' }}
+                                    onClick={() =>
+                                        drawer.open(
+                                            <AcknowledgeList targetCcid={props.id} initialTab="acknowledgers" />
+                                        )
+                                    }
+                                >
+                                    <Text>{`${stats.acknowledged} フォロワー`}</Text>
+                                </div>
                             </div>
                         </div>
                         <Tabs>

--- a/client/src/model.ts
+++ b/client/src/model.ts
@@ -55,6 +55,10 @@ export interface Entity {
     alias_proof_type: string
 }
 
+export interface Acknowledge {
+    context: string
+}
+
 export interface RealtimeEvent {
     type: string
     uri: string

--- a/worldlib/src/client.ts
+++ b/worldlib/src/client.ts
@@ -23,6 +23,11 @@ interface Cache<T> {
     expire: number
 }
 
+export interface Acknowledge {
+    author: string
+    associate: string
+}
+
 export class Client {
     api: Api
     ccid: string
@@ -35,8 +40,8 @@ export class Client {
 
     messageCache: Record<string, Cache<Promise<Message<any> | null>>> = {}
 
-    acknowledging: any
-    acknowledgers: any
+    acknowledging: Acknowledge[] = []
+    acknowledgers: Acknowledge[] = []
 
     constructor(api: Api, ccid: string, server: Server) {
         this.api = api
@@ -173,15 +178,8 @@ export class Client {
             }
         })
 
-        client.acknowledgers = await api.requestConcrntApi(client.server.domain, 'net.concrnt.core.acknowledges', {
-            to: client.ccid,
-            context: 'world.concrnt.ack'
-        })
-
-        client.acknowledging = await api.requestConcrntApi(client.server.domain, 'net.concrnt.core.acknowledges', {
-            from: client.ccid,
-            context: 'world.concrnt.ack'
-        })
+        client.acknowledgers = await client.getAcknowledgers(client.ccid)
+        client.acknowledging = await client.getAcknowledging(client.ccid)
 
         // =====================
 
@@ -264,10 +262,22 @@ export class Client {
         await this.reloadAcknowledges()
     }
 
-    async reloadAcknowledges(): Promise<void> {
-        this.acknowledging = await this.api.requestConcrntApi(this.server.domain, 'net.concrnt.core.acknowledges', {
-            from: this.ccid,
+    async getAcknowledging(ccid: string): Promise<Acknowledge[]> {
+        return await this.api.requestConcrntApi<Acknowledge[]>(this.server.domain, 'net.concrnt.core.acknowledges', {
+            from: ccid,
             context: 'world.concrnt.ack'
         })
+    }
+
+    async getAcknowledgers(ccid: string): Promise<Acknowledge[]> {
+        return await this.api.requestConcrntApi<Acknowledge[]>(this.server.domain, 'net.concrnt.core.acknowledges', {
+            to: ccid,
+            context: 'world.concrnt.ack'
+        })
+    }
+
+    async reloadAcknowledges(): Promise<void> {
+        this.acknowledging = await this.getAcknowledging(this.ccid)
+        this.acknowledgers = await this.getAcknowledgers(this.ccid)
     }
 }

--- a/worldlib/src/client.ts
+++ b/worldlib/src/client.ts
@@ -10,7 +10,8 @@ import {
     Socket,
     AuthProvider,
     KVS,
-    SignedDocument
+    SignedDocument,
+    Acknowledge
 } from '@concrnt/client'
 import { ListSchema } from './schemas/'
 import { User } from './user'
@@ -36,8 +37,8 @@ export class Client {
 
     messageCache: Record<string, Cache<Promise<Message<any> | null>>> = {}
 
-    acknowledging: Document<any>[] = []
-    acknowledgers: Document<any>[] = []
+    acknowledging: Document<Acknowledge>[] = []
+    acknowledgers: Document<Acknowledge>[] = []
 
     constructor(api: Api, ccid: string, server: Server) {
         this.api = api
@@ -258,7 +259,7 @@ export class Client {
         await this.reloadAcknowledges()
     }
 
-    getAcknowledging(ccid: string): Promise<Document<any>[]> {
+    getAcknowledging(ccid: string): Promise<Document<Acknowledge>[]> {
         return this.api
             .requestConcrntApi<Array<SignedDocument>>(this.server.domain, 'net.concrnt.core.acknowledges', {
                 from: ccid,
@@ -267,7 +268,7 @@ export class Client {
             .then((res) => res.map((sd) => JSON.parse(sd.document)))
     }
 
-    async getAcknowledgers(ccid: string): Promise<Document<any>[]> {
+    async getAcknowledgers(ccid: string): Promise<Document<Acknowledge>[]> {
         return this.api
             .requestConcrntApi<Array<SignedDocument>>(this.server.domain, 'net.concrnt.core.acknowledges', {
                 to: ccid,

--- a/worldlib/src/user.ts
+++ b/worldlib/src/user.ts
@@ -21,9 +21,12 @@ export class User {
             throw new Error('entity not found')
         })
 
-        const profile = await client.api.getDocument<ProfileSchema>(
-            `cckv://${entity.author}/concrnt.world/main/profile`
-        )
+        const profile = await client.api
+            .getDocument<ProfileSchema>(`cckv://${entity.author}/concrnt.world/main/profile`)
+            .catch((_e) => {
+                // ignore error, profile is optional
+                return undefined
+            })
 
         return new User(entity.value.domain, entity, profile?.value)
     }

--- a/worldlib/src/user.ts
+++ b/worldlib/src/user.ts
@@ -29,25 +29,23 @@ export class User {
     }
 
     async GetStats(client: Client): Promise<{ acknowledging: number; acknowledged: number }> {
-        const acknowledging = await client.api.requestConcrntApi<{ count: number }>(
+        const acknowledging = await client.api.requestConcrntApi<Record<string, number>>(
             client.server.domain,
             'net.concrnt.core.acknowledge-counts',
             {
                 from: this.ccid
             }
         )
-        console.log('acknowledging', acknowledging)
-        const acknowledged = await client.api.requestConcrntApi<{ count: number }>(
+        const acknowledged = await client.api.requestConcrntApi<Record<string, number>>(
             client.server.domain,
-            'net.concrnt.core.acknowledged-counts',
+            'net.concrnt.core.acknowledge-counts',
             {
                 to: this.ccid
             }
         )
-        console.log('acknowledged', acknowledged)
         return {
-            acknowledging: acknowledging.count,
-            acknowledged: acknowledged.count
+            acknowledging: acknowledging['world.concrnt.ack'] ?? 0,
+            acknowledged: acknowledged['world.concrnt.ack'] ?? 0
         }
     }
 }

--- a/worldlib/src/util.ts
+++ b/worldlib/src/util.ts
@@ -5,3 +5,7 @@ export function isFulfilled<T>(result: PromiseSettledResult<T>): result is Promi
 export function isNonNull<T>(value: T | null): value is T {
     return value !== null
 }
+
+export function isNonNullOrUndefined<T>(value: T | null | undefined): value is T {
+    return value !== null && value !== undefined
+}


### PR DESCRIPTION
resolve #28 
resolve #29 

## 概要

プロフィール画面にフォロー/フォロワー数の表示と、タップで一覧を見られる機能を実装しました。併せて、一覧の表示に使う Drawer コンポーネントの操作性と内部遷移の仕組みを整えています。

## 変更内容

### フォロー/フォロワー機能

- `AcknowledgeButton.tsx` を新設し、既存の Acknowledge/Unacknowledge 操作を抽出
  - ラベルを `フォロー` / `フォロー中` に統一
- プロフィールにフォロー/フォロワー数のカウントを追加
  - 初期値を `0` にし、未ロード時でも数字で表示
  - タップで Drawer を開き、一覧を表示
- `AcknowledgeList.tsx` を新設
  - タブで `フォロー` / `フォロワー` を切替
  - 各行のアバター・ユーザー名タップで、該当ユーザーの Profile へ (Drawer 内で) 遷移
  - 各行に `AcknowledgeButton` を配置
- `Contacts.tsx` に自分用の `AcknowledgeList` を埋め込み

### worldlib

- `Client` クラスに以下を追加/修正
  - `getAcknowledging(ccid)` / `getAcknowledgers(ccid)` を追加(任意の ccid 対応)
  - `reloadAcknowledges()` で `acknowledgers` も再読込するよう修正
  - `acknowledging` / `acknowledgers` プロパティの型を `any` から `Acknowledge[]` に

### Drawer の改善

- ドラッグハンドルの当たり判定を拡張(見た目は変えず)
  - ハンドル中心から 上 40px / 下 8px のヒット領域に
- Drawer 内部に独立した `StackLayout` を配置
  - Drawer 内での遷移が裏のタブの Stack に干渉しないよう分離
- Android バックボタン押下時の挙動を整備
  - ドロワーが開いている間はドロワー側で横取り
  - `Drawer 内 Stack を pop → 空ならドロワーを閉じる` の優先順で処理

## 動作確認

### 確認済み

- [x] プロフィール画面にフォロー/フォロワー数が表示される (サーバー未実装のため現状は `0` 表示)
- [x] カウントタップで Drawer が開く
- [x] Drawer 内のタブ切替が動作
- [x] Drawer のドラッグ/バックドロップタップで閉じられる
- [x] Android バックボタンで「ドロワーだけ閉じる」動作
- [x] フォローボタンのテキスト切替が表示上は正しく動作

### 未確認(サーバー実装(?)待ち)

- [ ] フォロー状態のサーバー永続化
- [ ] Drawer 内リストから別ユーザーの Profile へ遷移
- [ ] Drawer 内 Stack の pop(戻る操作)
- [ ] 実データでのカウント表示

> Concurrent サーバー側の `net.concrnt.core.acknowledges` / `...acknowledge-counts` / `...acknowledged-counts` が未実装(?)のため、該当APIを叩く機能は検証できていません。サーバー側が実装されたら再検証します。

## スクリーンショット
<img width="406" height="256" alt="Screenshot 2026-04-16 18 41 44" src="https://github.com/user-attachments/assets/15dd8112-f357-429c-ac7e-55b2aec0d91e" />
<img width="412" height="258" alt="Screenshot 2026-04-16 18 42 06" src="https://github.com/user-attachments/assets/a81b01c7-fc39-4637-9645-56d3ce82c5c0" />
<img width="459" height="959" alt="Screenshot 2026-04-16 18 49 03" src="https://github.com/user-attachments/assets/eaba4126-e9c9-420f-9ea4-40c8e68e58a3" />

## 備考

- `worldlib/src/user.ts` の `User.GetStats()` に気になる点 (`console.log` 残存、`context` 未指定)  がありましたが、今回のスコープ外としました。

