### PR TITLE
リプライ/リルート時にコミュニティ投稿先を設定できるようにしました

### DIFF
--- a/app/src/components/message/MessageActions.tsx
+++ b/app/src/components/message/MessageActions.tsx
@@ -48,7 +48,15 @@ export const MessageActions = (props: Props) => {
                 variant="text"
                 onClick={(e) => {
                     e.stopPropagation()
-                    composer.open([], [], 'reply', props.message)
+                    // 元メッセージのコミュニティ投稿先を抽出（homeタイムラインは除外）
+                    const communityDestinations =
+                        props.message.distributes?.filter(
+                            (uri) =>
+                                !uri.includes('/main/home-timeline') &&
+                                !uri.includes('/main/activity-timeline') &&
+                                !uri.includes('/main/notify-timeline')
+                        ) ?? []
+                    composer.open(communityDestinations, [], 'reply', props.message)
                 }}
                 style={{ display: 'flex', alignItems: 'center' }}
             >
@@ -61,7 +69,14 @@ export const MessageActions = (props: Props) => {
                 variant="text"
                 onClick={(e) => {
                     e.stopPropagation()
-                    composer.open([], [], 'reroute', props.message)
+                    const communityDestinations =
+                        props.message.distributes?.filter(
+                            (uri) =>
+                                !uri.includes('/main/home-timeline') &&
+                                !uri.includes('/main/activity-timeline') &&
+                                !uri.includes('/main/notify-timeline')
+                        ) ?? []
+                    composer.open(communityDestinations, [], 'reroute', props.message)
                 }}
                 style={{ display: 'flex', alignItems: 'center' }}
             >

--- a/app/src/contexts/Composer.tsx
+++ b/app/src/contexts/Composer.tsx
@@ -7,6 +7,7 @@ export type ComposerMode = 'normal' | 'reply' | 'reroute'
 interface ComposerContextState {
     open: (destinations: string[], options: any[], mode?: ComposerMode, targetMessage?: Message<any>) => void
     close: () => void
+    setCommunityOptions: (options: any[]) => void
 }
 
 interface Props {
@@ -15,7 +16,8 @@ interface Props {
 
 const ComposerContext = createContext<ComposerContextState>({
     open: () => {},
-    close: () => {}
+    close: () => {},
+    setCommunityOptions: () => {}
 })
 
 export const ComposerProvider = (props: Props) => {
@@ -24,16 +26,22 @@ export const ComposerProvider = (props: Props) => {
     const [options, setOptions] = useState<any[]>([])
     const [mode, setMode] = useState<ComposerMode>('normal')
     const [targetMessage, setTargetMessage] = useState<Message<any> | undefined>(undefined)
+    const [communityOptions, _setCommunityOptions] = useState<any[]>([])
+
+    const setCommunityOptions = useCallback((options: any[]) => {
+        _setCommunityOptions(options)
+    }, [])
 
     const open = useCallback(
         (destinations: string[], options: any[], mode?: ComposerMode, targetMessage?: Message<any>) => {
             setDestinations(destinations)
-            setOptions(options)
+            // options が空の場合は保持済みの communityOptions にフォールバック
+            setOptions(options.length > 0 ? options : communityOptions)
             setMode(mode ?? 'normal')
             setTargetMessage(targetMessage)
             setShowComposer(true)
         },
-        []
+        [communityOptions]
     )
 
     const close = useCallback(() => {
@@ -45,9 +53,10 @@ export const ComposerProvider = (props: Props) => {
     const value = useMemo(
         () => ({
             open,
-            close
+            close,
+            setCommunityOptions
         }),
-        [open, close]
+        [open, close, setCommunityOptions]
     )
 
     return (

--- a/app/src/views/Home.tsx
+++ b/app/src/views/Home.tsx
@@ -179,6 +179,11 @@ const InnerFab = (props: { defaultPostTimelines: string[]; communitiesPromise: P
     const communities = use(props.communitiesPromise)
     console.log('communities', communities)
 
+    // コミュニティ選択肢をComposerContextにグローバル保持
+    useEffect(() => {
+        composer.setCommunityOptions(communities)
+    }, [communities])
+
     return (
         <FAB
             onClick={() => {

--- a/app/src/views/Timeline.tsx
+++ b/app/src/views/Timeline.tsx
@@ -31,8 +31,8 @@ export const TimelineView = (props: Props) => {
             <FAB
                 onClick={() => {
                     hapticLight()
-                    timelinePromise.then((timeline) => {
-                        composer.open([props.uri], timeline ? [timeline] : [])
+                    timelinePromise.then(() => {
+                        composer.open([props.uri], [])
                     })
                 }}
             >


### PR DESCRIPTION
closes #41

## 概要

リプライ・リルート時およびコミュニティ画面での投稿時に「投稿先を追加」が機能せず、Homeにしか投稿できなかった問題を修正しました。

## 原因

- `MessageActions` から `composer.open([], [])` と、destinations（投稿先）も options（選択肢）も空配列で渡していたため、TimelinePicker に選択肢が表示されなかった。
- `TimelineView` では options に現在のコミュニティ1つだけを渡しつつ、destinations にも同じURIを入れていたため、TimelinePicker の残り選択肢が0件になっていた。

## 修正内容

### ComposerContext (`contexts/Composer.tsx`)
- `communityOptions` ステートを追加し、コミュニティ選択肢をグローバル保持
- `setCommunityOptions` メソッドを公開
- `open()` で options が空配列の場合、保持済みの communityOptions にフォールバック

### HomeView (`views/Home.tsx`)
- コミュニティ一覧の解決後に `setCommunityOptions` でComposerContextに保持

### MessageActions (`components/message/MessageActions.tsx`)
- リプライ・リルートボタン押下時に `message.distributes` から元メッセージのコミュニティ投稿先を抽出し destinations に設定
- home-timeline / activity-timeline / notify-timeline は除外

### TimelineView (`views/Timeline.tsx`)
- options を空配列に変更し、ComposerContextの communityOptions にフォールバックさせる
- destinations には現在のコミュニティURIを維持（プリセレクト）

## 動作

1. Home画面表示時にコミュニティ一覧がComposerContextに保持される
2. リプライボタン押下 → 元メッセージの投稿先コミュニティが destinations にプリセレクト
3. コミュニティ画面で投稿 → 現在のコミュニティがプリセレクト
4. いずれの場合も「投稿先を追加」でコミュニティ一覧が表示され、追加・削除が可能