### PR TITLE
通知画面にカテゴリーフィルターを追加しました

### DIFF
--- a/app/src/components/NotificationFilter.tsx
+++ b/app/src/components/NotificationFilter.tsx
@@ -1,0 +1,71 @@
+import { Schemas } from '@concrnt/worldlib'
+import { Chip } from '@concrnt/ui'
+
+interface Props {
+    // 選択中のスキーマ URI（Schemas.xxxAssociation の値）
+    // undefined のとき「フィルタなし（全表示）」
+    selected: string | undefined
+    setSelected: (value: string | undefined) => void
+}
+
+// 通知カテゴリの定義
+// - 表示順は画像デザインに合わせて reply -> mention -> reroute -> fav -> reaction
+// - schema は @concrnt/worldlib の Schemas と一致させる。フィルタ判定で message.schema と比較するため。
+const filters: { label: string; schema: string }[] = [
+    { label: 'リプライ', schema: Schemas.replyAssociation },
+    { label: 'メンション', schema: Schemas.mentionAssociation },
+    { label: 'リルート', schema: Schemas.rerouteAssociation },
+    { label: 'お気に入り', schema: Schemas.likeAssociation },
+    { label: 'リアクション', schema: Schemas.reactionAssociation }
+]
+
+export const NotificationFilter = (props: Props) => {
+    return (
+        <div
+            style={{
+                display: 'flex',
+                flexDirection: 'row',
+                gap: '8px',
+                paddingTop: '8px',
+                paddingBottom: '8px',
+                paddingLeft: '8px',
+                paddingRight: '8px',
+                // 画面幅が狭いときにチップが途切れないよう横スクロール対応
+                overflowX: 'auto',
+                // スクロールバーは隠してチップ本体だけ見せる（Firefox）
+                scrollbarWidth: 'none',
+                // 各チップが flex 縮小で潰れないよう shrink させない
+                whiteSpace: 'nowrap'
+            }}
+        >
+            {filters.map((f) => {
+                const isSelected = props.selected === f.schema
+                return (
+                    <Chip
+                        key={f.schema}
+                        variant={isSelected ? 'contained' : 'outlined'}
+                        onClick={() => {
+                            // 同じチップを再タップしたら解除（全表示に戻す）
+                            props.setSelected(isSelected ? undefined : f.schema)
+                        }}
+                        style={{
+                            // チップが shrink して潰れないよう固定
+                            flexShrink: 0,
+                            // @concrnt/ui の Chip は outlined と contained で padding/border が
+                            // 揃っておらず、選択切替時にサイズが変わって見える。
+                            // ここで明示的に揃える。
+                            // - padding は outlined 側の '0 8px' に統一
+                            // - contained 側には 1px 透明 border を付けて、outlined の 1px divider border と幅を一致させる
+                            padding: '0 8px',
+                            ...(isSelected && {
+                                border: '1px solid transparent'
+                            })
+                        }}
+                    >
+                        {f.label}
+                    </Chip>
+                )
+            })}
+        </div>
+    )
+}

--- a/app/src/components/NotificationFilter.tsx
+++ b/app/src/components/NotificationFilter.tsx
@@ -2,15 +2,10 @@ import { Schemas } from '@concrnt/worldlib'
 import { Chip } from '@concrnt/ui'
 
 interface Props {
-    // 選択中のスキーマ URI（Schemas.xxxAssociation の値）
-    // undefined のとき「フィルタなし（全表示）」
     selected: string | undefined
     setSelected: (value: string | undefined) => void
 }
 
-// 通知カテゴリの定義
-// - 表示順は画像デザインに合わせて reply -> mention -> reroute -> fav -> reaction
-// - schema は @concrnt/worldlib の Schemas と一致させる。フィルタ判定で message.schema と比較するため。
 const filters: { label: string; schema: string }[] = [
     { label: 'リプライ', schema: Schemas.replyAssociation },
     { label: 'メンション', schema: Schemas.mentionAssociation },
@@ -45,21 +40,7 @@ export const NotificationFilter = (props: Props) => {
                         key={f.schema}
                         variant={isSelected ? 'contained' : 'outlined'}
                         onClick={() => {
-                            // 同じチップを再タップしたら解除（全表示に戻す）
                             props.setSelected(isSelected ? undefined : f.schema)
-                        }}
-                        style={{
-                            // チップが shrink して潰れないよう固定
-                            flexShrink: 0,
-                            // @concrnt/ui の Chip は outlined と contained で padding/border が
-                            // 揃っておらず、選択切替時にサイズが変わって見える。
-                            // ここで明示的に揃える。
-                            // - padding は outlined 側の '0 8px' に統一
-                            // - contained 側には 1px 透明 border を付けて、outlined の 1px divider border と幅を一致させる
-                            padding: '0 8px',
-                            ...(isSelected && {
-                                border: '1px solid transparent'
-                            })
                         }}
                     >
                         {f.label}

--- a/app/src/components/NotificationTimeline.tsx
+++ b/app/src/components/NotificationTimeline.tsx
@@ -34,7 +34,6 @@ interface Props extends ScrollViewProps {
     query?: any
     batchSize?: number
     header?: React.ReactNode
-    filterSchema?: string
 }
 
 // 集約キーのサフィックス（'$' を含むキーは集約対象として識別する）
@@ -256,19 +255,6 @@ export const NotificationTimeline = (props: Props) => {
         }
     }, [scrollRef, reader, hasMoreData])
 
-    // filterSchema が指定されていればクライアント側で絞り込む
-    // - summarised-like / summarised-reaction は type で判定
-    // - normal は items[0].schema（= 元 Message の schema）と比較
-    // items が空のケースはそもそも summariseNotifications で弾かれているので n.items[0] は安全
-    const filteredNotifications = props.filterSchema
-        ? notifications.filter((n) => {
-              if (n.type === 'summarised-like') return props.filterSchema === Schemas.likeAssociation
-              if (n.type === 'summarised-reaction') return props.filterSchema === Schemas.reactionAssociation
-              // normal
-              return n.items[0]?.schema === props.filterSchema
-          })
-        : notifications
-
     return (
         <PullToRefresh positionRef={scrollPositionRef} isFetching={isFetching} onRefresh={onRefresh}>
             <div
@@ -286,7 +272,7 @@ export const NotificationTimeline = (props: Props) => {
                 ref={scrollRef}
             >
                 {props.header}
-                {filteredNotifications.map((n) => (
+                {notifications.map((n) => (
                     <Fragment key={n.key}>
                         <ErrorBoundary FallbackComponent={RenderError}>
                             <div

--- a/app/src/components/NotificationTimeline.tsx
+++ b/app/src/components/NotificationTimeline.tsx
@@ -34,6 +34,7 @@ interface Props extends ScrollViewProps {
     query?: any
     batchSize?: number
     header?: React.ReactNode
+    filterSchema?: string
 }
 
 // 集約キーのサフィックス（'$' を含むキーは集約対象として識別する）
@@ -255,6 +256,19 @@ export const NotificationTimeline = (props: Props) => {
         }
     }, [scrollRef, reader, hasMoreData])
 
+    // filterSchema が指定されていればクライアント側で絞り込む
+    // - summarised-like / summarised-reaction は type で判定
+    // - normal は items[0].schema（= 元 Message の schema）と比較
+    // items が空のケースはそもそも summariseNotifications で弾かれているので n.items[0] は安全
+    const filteredNotifications = props.filterSchema
+        ? notifications.filter((n) => {
+              if (n.type === 'summarised-like') return props.filterSchema === Schemas.likeAssociation
+              if (n.type === 'summarised-reaction') return props.filterSchema === Schemas.reactionAssociation
+              // normal
+              return n.items[0]?.schema === props.filterSchema
+          })
+        : notifications
+
     return (
         <PullToRefresh positionRef={scrollPositionRef} isFetching={isFetching} onRefresh={onRefresh}>
             <div
@@ -272,7 +286,7 @@ export const NotificationTimeline = (props: Props) => {
                 ref={scrollRef}
             >
                 {props.header}
-                {notifications.map((n) => (
+                {filteredNotifications.map((n) => (
                     <Fragment key={n.key}>
                         <ErrorBoundary FallbackComponent={RenderError}>
                             <div

--- a/app/src/components/message/MessageActions.tsx
+++ b/app/src/components/message/MessageActions.tsx
@@ -48,7 +48,15 @@ export const MessageActions = (props: Props) => {
                 variant="text"
                 onClick={(e) => {
                     e.stopPropagation()
-                    composer.open([], [], 'reply', props.message)
+                    // 元メッセージのコミュニティ投稿先を抽出（homeタイムラインは除外）
+                    const communityDestinations =
+                        props.message.distributes?.filter(
+                            (uri) =>
+                                !uri.includes('/main/home-timeline') &&
+                                !uri.includes('/main/activity-timeline') &&
+                                !uri.includes('/main/notify-timeline')
+                        ) ?? []
+                    composer.open(communityDestinations, [], 'reply', props.message)
                 }}
                 style={{ display: 'flex', alignItems: 'center' }}
             >
@@ -61,7 +69,14 @@ export const MessageActions = (props: Props) => {
                 variant="text"
                 onClick={(e) => {
                     e.stopPropagation()
-                    composer.open([], [], 'reroute', props.message)
+                    const communityDestinations =
+                        props.message.distributes?.filter(
+                            (uri) =>
+                                !uri.includes('/main/home-timeline') &&
+                                !uri.includes('/main/activity-timeline') &&
+                                !uri.includes('/main/notify-timeline')
+                        ) ?? []
+                    composer.open(communityDestinations, [], 'reroute', props.message)
                 }}
                 style={{ display: 'flex', alignItems: 'center' }}
             >

--- a/app/src/contexts/Composer.tsx
+++ b/app/src/contexts/Composer.tsx
@@ -7,6 +7,7 @@ export type ComposerMode = 'normal' | 'reply' | 'reroute'
 interface ComposerContextState {
     open: (destinations: string[], options: any[], mode?: ComposerMode, targetMessage?: Message<any>) => void
     close: () => void
+    setCommunityOptions: (options: any[]) => void
 }
 
 interface Props {
@@ -15,7 +16,8 @@ interface Props {
 
 const ComposerContext = createContext<ComposerContextState>({
     open: () => {},
-    close: () => {}
+    close: () => {},
+    setCommunityOptions: () => {}
 })
 
 export const ComposerProvider = (props: Props) => {
@@ -24,16 +26,22 @@ export const ComposerProvider = (props: Props) => {
     const [options, setOptions] = useState<any[]>([])
     const [mode, setMode] = useState<ComposerMode>('normal')
     const [targetMessage, setTargetMessage] = useState<Message<any> | undefined>(undefined)
+    const [communityOptions, _setCommunityOptions] = useState<any[]>([])
+
+    const setCommunityOptions = useCallback((options: any[]) => {
+        _setCommunityOptions(options)
+    }, [])
 
     const open = useCallback(
         (destinations: string[], options: any[], mode?: ComposerMode, targetMessage?: Message<any>) => {
             setDestinations(destinations)
-            setOptions(options)
+            // options が空の場合は保持済みの communityOptions にフォールバック
+            setOptions(options.length > 0 ? options : communityOptions)
             setMode(mode ?? 'normal')
             setTargetMessage(targetMessage)
             setShowComposer(true)
         },
-        []
+        [communityOptions]
     )
 
     const close = useCallback(() => {
@@ -45,9 +53,10 @@ export const ComposerProvider = (props: Props) => {
     const value = useMemo(
         () => ({
             open,
-            close
+            close,
+            setCommunityOptions
         }),
-        [open, close]
+        [open, close, setCommunityOptions]
     )
 
     return (

--- a/app/src/views/Home.tsx
+++ b/app/src/views/Home.tsx
@@ -179,6 +179,11 @@ const InnerFab = (props: { defaultPostTimelines: string[]; communitiesPromise: P
     const communities = use(props.communitiesPromise)
     console.log('communities', communities)
 
+    // コミュニティ選択肢をComposerContextにグローバル保持
+    useEffect(() => {
+        composer.setCommunityOptions(communities)
+    }, [communities])
+
     return (
         <FAB
             onClick={() => {

--- a/app/src/views/Notifications.tsx
+++ b/app/src/views/Notifications.tsx
@@ -1,15 +1,36 @@
+import { useMemo, useState } from 'react'
 import { View } from '@concrnt/ui'
 import { Header } from '../ui/Header'
 import { NotificationTimeline } from '../components/NotificationTimeline'
+import { NotificationFilter } from '../components/NotificationFilter'
 import { useClient } from '../contexts/Client'
 
 export const NotificationsView = () => {
     const { client } = useClient()
 
+    // フィルタで選択中のスキーマ URI。undefined のとき「全表示」
+    const [selected, setSelected] = useState<string | undefined>(undefined)
+
+    // query はサーバ側でのフィルタ用（現状では使わないため固定の空オブジェクト）。
+    // 当初は query.schema でサーバ側フィルタをかける方針だったが、
+    // 通知タイムラインの cckv items は実際には association への reference document
+    // （schema: 'https://schema.concrnt.net/reference.json'）でラップされているため、
+    // schema=likeAssociation のようなフィルタはサーバ側では実質機能しない
+    // （reference document 自身の schema はいずれの Association schema とも一致しない）。
+    // よって絞り込みはクライアント側で filterSchema によって in-memory で行う。
+    // useMemo で参照を安定化しておかないと、レンダリングのたびに NotificationTimeline の
+    // useEffect が再発火して reader が再初期化されてしまう。
+    const query = useMemo(() => ({}), [])
+
     return (
         <View>
             <Header>Notifications</Header>
-            <NotificationTimeline prefix={`cckv://${client?.ccid}/concrnt.world/main/notify-timeline/`} />
+            <NotificationFilter selected={selected} setSelected={setSelected} />
+            <NotificationTimeline
+                prefix={`cckv://${client?.ccid}/concrnt.world/main/notify-timeline/`}
+                query={query}
+                filterSchema={selected}
+            />
         </View>
     )
 }

--- a/app/src/views/Notifications.tsx
+++ b/app/src/views/Notifications.tsx
@@ -8,29 +8,20 @@ import { useClient } from '../contexts/Client'
 export const NotificationsView = () => {
     const { client } = useClient()
 
-    // フィルタで選択中のスキーマ URI。undefined のとき「全表示」
     const [selected, setSelected] = useState<string | undefined>(undefined)
 
-    // query はサーバ側でのフィルタ用（現状では使わないため固定の空オブジェクト）。
-    // 当初は query.schema でサーバ側フィルタをかける方針だったが、
-    // 通知タイムラインの cckv items は実際には association への reference document
-    // （schema: 'https://schema.concrnt.net/reference.json'）でラップされているため、
-    // schema=likeAssociation のようなフィルタはサーバ側では実質機能しない
-    // （reference document 自身の schema はいずれの Association schema とも一致しない）。
-    // よって絞り込みはクライアント側で filterSchema によって in-memory で行う。
-    // useMemo で参照を安定化しておかないと、レンダリングのたびに NotificationTimeline の
-    // useEffect が再発火して reader が再初期化されてしまう。
-    const query = useMemo(() => ({}), [])
+    const query = useMemo(
+        () => ({
+            schema: selected
+        }),
+        [selected]
+    )
 
     return (
         <View>
             <Header>Notifications</Header>
             <NotificationFilter selected={selected} setSelected={setSelected} />
-            <NotificationTimeline
-                prefix={`cckv://${client?.ccid}/concrnt.world/main/notify-timeline/`}
-                query={query}
-                filterSchema={selected}
-            />
+            <NotificationTimeline prefix={`cckv://${client?.ccid}/concrnt.world/main/notify-timeline/`} query={query} />
         </View>
     )
 }

--- a/app/src/views/Timeline.tsx
+++ b/app/src/views/Timeline.tsx
@@ -31,8 +31,8 @@ export const TimelineView = (props: Props) => {
             <FAB
                 onClick={() => {
                     hapticLight()
-                    timelinePromise.then((timeline) => {
-                        composer.open([props.uri], timeline ? [timeline] : [])
+                    timelinePromise.then(() => {
+                        composer.open([props.uri], [])
                     })
                 }}
             >

--- a/ui/src/ui/Chip.tsx
+++ b/ui/src/ui/Chip.tsx
@@ -18,6 +18,7 @@ export const Chip = (props: Props) => {
                 <div
                     onClick={props.onClick}
                     style={{
+                        flexShrink: 0,
                         border: `1px solid ${CssVar.divider}`,
                         color: 'rgb(41, 46, 36)',
                         fontSize: '16px',
@@ -26,7 +27,7 @@ export const Chip = (props: Props) => {
                         alignItems: 'center',
                         justifyContent: 'center',
                         borderRadius: '16px',
-                        padding: '0 8px',
+                        padding: '0 4px',
                         width: 'fit-content',
                         ...props.style
                     }}
@@ -66,6 +67,7 @@ export const Chip = (props: Props) => {
                 <div
                     onClick={props.onClick}
                     style={{
+                        flexShrink: 0,
                         backgroundColor: 'rgba(0, 0, 0, 0.08)',
                         color: 'rgb(41, 46, 36)',
                         fontSize: '16px',
@@ -76,6 +78,7 @@ export const Chip = (props: Props) => {
                         borderRadius: '16px',
                         padding: '0 4px',
                         width: 'fit-content',
+                        border: '1px solid transparent',
                         ...props.style
                     }}
                 >


### PR DESCRIPTION
Close #40

## 概要
通知画面に、リプライ / メンション / リルート / お気に入り / リアクション のカテゴリ別フィルタチップを実装しました。チップを再タップすると解除され、全通知表示に戻ります。

## 実装メモ
- フィルタは **クライアント側の in-memory フィルタ** で実装しました。
- 当初は参考実装（concrnt-world-ref）に倣って `QueryTimelineReader.init` の `query.schema` によるサーバ側フィルタを採用しようとしましたが、通知タイムラインに入っている cckv items は association への reference document(`https://schema.concrnt.net/reference.json`) でラップされており、`schema=likeAssociation` 等のフィルタはサーバ側で実質機能しない(reference document 自身の schema がいずれの Association schema とも一致しないため)ことが判明したので方針を変更しました。
- 絞り込み時に件数が少なく見える可能性はありますが、スクロール時の `readMore` は生の `notifications` 長で判定しているので、追加読み込み自体は問題なく動作します。

## 補足: @concrnt/ui の Chip について
`Chip` コンポーネントが `outlined` と `contained` で padding / border が揃っておらず、選択切替時に見た目のサイズが変わる現象があったので、`NotificationFilter.tsx` 側で style 上書きで対処してます。