### PR TITLE
音声データに対応しました/モデルデータに対応しようとしました

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
     "@concrnt/client": "workspace:*",
     "@concrnt/ui": "workspace:*",
     "@concrnt/worldlib": "workspace:*",
+    "@google/model-viewer": "^4.2.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-barcode-scanner": "^2.4.4",
     "@tauri-apps/plugin-haptics": "^2.3.2",

--- a/app/src/components/ModelViewer.tsx
+++ b/app/src/components/ModelViewer.tsx
@@ -1,0 +1,50 @@
+import { CSSProperties, useEffect, useState } from 'react'
+
+interface ModelViewerProps {
+    src: string
+    style?: CSSProperties
+}
+
+export const ModelViewer = (props: ModelViewerProps) => {
+    const [loaded, setLoaded] = useState(false)
+
+    useEffect(() => {
+        import('@google/model-viewer')
+            .then(() => setLoaded(true))
+            .catch(() => console.warn('model-viewer failed to load'))
+    }, [])
+
+    if (!loaded) {
+        return (
+            <div
+                style={{
+                    ...props.style,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color: 'rgba(255,255,255,0.6)'
+                }}
+            >
+                Loading...
+            </div>
+        )
+    }
+
+    return <model-viewer src={props.src} autoplay camera-controls style={props.style} />
+}
+
+declare module 'react' {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace JSX {
+        interface IntrinsicElements {
+            'model-viewer': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+                src: string
+                alt?: string
+                'camera-controls'?: boolean
+                'auto-rotate'?: boolean
+                ar?: boolean
+                autoplay?: boolean
+            }
+        }
+    }
+}

--- a/app/src/components/message/MediaMessage.tsx
+++ b/app/src/components/message/MediaMessage.tsx
@@ -6,8 +6,10 @@ import { ProfileView } from '../../views/Profile'
 import { PostView } from '../../views/Post'
 
 import { Avatar, CfmRenderer, CssVar } from '@concrnt/ui'
+import { MdPlayCircle, MdStop, MdViewInAr } from 'react-icons/md'
 
 import { useMediaViewer } from '../../contexts/MediaViewer'
+import { useAudioPlayer } from '../../contexts/AudioPlayer'
 import { MessageActions } from './MessageActions'
 import { MessageLayout } from './MessageLayout'
 import { TimeDiff } from '../TimeDiff'
@@ -16,6 +18,7 @@ import { PostedTimelines } from './PostedTimelines'
 export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
     const { push } = useStack()
     const mediaViewer = useMediaViewer()
+    const audioPlayer = useAudioPlayer()
 
     const message = props.message
 
@@ -69,10 +72,18 @@ export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
                             }}
                             onClick={(e) => {
                                 e.stopPropagation()
-                                const imageMedias = medias.filter((m) => m.mediaType.startsWith('image/'))
-                                const viewerIndex = imageMedias.findIndex((m) => m.mediaURL === media.mediaURL)
                                 if (media.mediaType.startsWith('image/')) {
+                                    const imageMedias = medias.filter((m) => m.mediaType.startsWith('image/'))
+                                    const viewerIndex = imageMedias.findIndex((m) => m.mediaURL === media.mediaURL)
                                     mediaViewer.open(imageMedias, viewerIndex >= 0 ? viewerIndex : 0)
+                                } else if (media.mediaType.startsWith('audio/')) {
+                                    if (audioPlayer.nowPlaying === media.mediaURL) {
+                                        audioPlayer.stop()
+                                    } else {
+                                        audioPlayer.play(media.mediaURL)
+                                    }
+                                } else if (media.mediaType.startsWith('model/')) {
+                                    mediaViewer.openModel(media.mediaURL)
                                 }
                             }}
                         >
@@ -97,6 +108,45 @@ export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
                                         maxHeight: '300px'
                                     }}
                                 />
+                            ) : media.mediaType.startsWith('audio/') ? (
+                                <div
+                                    style={{
+                                        width: '100%',
+                                        height: medias.length === 1 ? '80px' : '100%',
+                                        minHeight: '80px',
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        backgroundColor: 'rgba(0, 0, 0, 0.15)',
+                                        cursor: 'pointer'
+                                    }}
+                                >
+                                    {audioPlayer.nowPlaying === media.mediaURL ? (
+                                        <MdStop size={48} style={{ color: 'rgba(255, 255, 255, 0.8)' }} />
+                                    ) : (
+                                        <MdPlayCircle size={48} style={{ color: 'rgba(255, 255, 255, 0.8)' }} />
+                                    )}
+                                </div>
+                            ) : media.mediaType.startsWith('model/') ? (
+                                <div
+                                    style={{
+                                        width: '100%',
+                                        height: medias.length === 1 ? '120px' : '100%',
+                                        minHeight: '100px',
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        backgroundColor: 'rgba(0, 0, 0, 0.15)',
+                                        cursor: 'pointer',
+                                        gap: '8px'
+                                    }}
+                                >
+                                    <MdViewInAr size={48} style={{ color: 'rgba(255, 255, 255, 0.8)' }} />
+                                    <span style={{ color: 'rgba(255, 255, 255, 0.6)', fontSize: '12px' }}>
+                                        3D Model
+                                    </span>
+                                </div>
                             ) : (
                                 <div>Unsupported media type: {media.mediaType}</div>
                             )}

--- a/app/src/contexts/AudioPlayer.tsx
+++ b/app/src/contexts/AudioPlayer.tsx
@@ -1,0 +1,245 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { MdPlayArrow, MdPause, MdClose, MdMusicNote } from 'react-icons/md'
+import { CssVar } from '../types/Theme'
+
+export interface AudioPlayerState {
+    nowPlaying: string | null
+    play: (src: string) => void
+    stop: () => void
+}
+
+const AudioPlayerContext = createContext<AudioPlayerState>({
+    nowPlaying: null,
+    play: () => {},
+    stop: () => {}
+})
+
+interface Props {
+    children: React.ReactNode
+}
+
+const formatTime = (seconds: number): string => {
+    const safe = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0
+    const m = Math.floor(safe / 60)
+    const s = safe % 60
+    return `${m}:${String(s).padStart(2, '0')}`
+}
+
+export const AudioPlayerProvider = (props: Props) => {
+    const audioRef = useRef<HTMLAudioElement | null>(null)
+    const [src, setSrc] = useState<string | null>(null)
+    const [isPlaying, setIsPlaying] = useState(false)
+    const [duration, setDuration] = useState(0)
+    const [currentTime, setCurrentTime] = useState(0)
+
+    useEffect(() => {
+        const audio = new Audio()
+        audio.preload = 'metadata'
+        audioRef.current = audio
+
+        const onPlay = () => setIsPlaying(true)
+        const onPause = () => setIsPlaying(false)
+        const onEnded = () => {
+            setIsPlaying(false)
+            setCurrentTime(0)
+        }
+        const onLoadedMetadata = () => {
+            if (Number.isFinite(audio.duration)) {
+                setDuration(audio.duration)
+            }
+        }
+        const onDurationChange = () => {
+            if (Number.isFinite(audio.duration)) {
+                setDuration(audio.duration)
+            }
+        }
+        const onTimeUpdate = () => {
+            setCurrentTime(audio.currentTime)
+        }
+
+        audio.addEventListener('play', onPlay)
+        audio.addEventListener('pause', onPause)
+        audio.addEventListener('ended', onEnded)
+        audio.addEventListener('loadedmetadata', onLoadedMetadata)
+        audio.addEventListener('durationchange', onDurationChange)
+        audio.addEventListener('timeupdate', onTimeUpdate)
+
+        return () => {
+            audio.removeEventListener('play', onPlay)
+            audio.removeEventListener('pause', onPause)
+            audio.removeEventListener('ended', onEnded)
+            audio.removeEventListener('loadedmetadata', onLoadedMetadata)
+            audio.removeEventListener('durationchange', onDurationChange)
+            audio.removeEventListener('timeupdate', onTimeUpdate)
+            audio.pause()
+            audio.removeAttribute('src')
+            audio.load()
+        }
+    }, [])
+
+    const play = useCallback(
+        (nextSrc: string) => {
+            const audio = audioRef.current
+            if (!audio) return
+
+            if (src === nextSrc) {
+                if (isPlaying) {
+                    audio.pause()
+                } else {
+                    void audio.play()
+                }
+                return
+            }
+
+            audio.src = nextSrc
+            audio.currentTime = 0
+            setCurrentTime(0)
+            setDuration(0)
+            setSrc(nextSrc)
+            void audio.play().catch(() => setIsPlaying(false))
+        },
+        [src, isPlaying]
+    )
+
+    const stop = useCallback(() => {
+        const audio = audioRef.current
+        if (audio) {
+            audio.pause()
+            audio.removeAttribute('src')
+            audio.load()
+        }
+        setSrc(null)
+        setIsPlaying(false)
+        setCurrentTime(0)
+        setDuration(0)
+    }, [])
+
+    const togglePlay = useCallback(() => {
+        const audio = audioRef.current
+        if (!audio || !src) return
+        if (isPlaying) {
+            audio.pause()
+        } else {
+            void audio.play()
+        }
+    }, [src, isPlaying])
+
+    const handleSeek = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        const audio = audioRef.current
+        if (!audio) return
+        const time = Number(e.target.value)
+        audio.currentTime = time
+        setCurrentTime(time)
+    }, [])
+
+    const value = useMemo(() => ({ nowPlaying: src, play, stop }), [src, play, stop])
+
+    return (
+        <AudioPlayerContext.Provider value={value}>
+            {props.children}
+
+            {src && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        bottom: 'calc(52px + env(safe-area-inset-bottom))',
+                        left: 0,
+                        right: 0,
+                        zIndex: 9000,
+                        padding: '0 8px'
+                    }}
+                >
+                    <div
+                        style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '8px',
+                            padding: '8px 12px',
+                            borderRadius: '12px',
+                            backgroundColor: CssVar.uiBackground,
+                            color: CssVar.uiText,
+                            boxShadow: '0 2px 12px rgba(0,0,0,0.25)'
+                        }}
+                    >
+                        <button
+                            onClick={togglePlay}
+                            style={{
+                                background: 'none',
+                                border: 'none',
+                                color: 'inherit',
+                                padding: '4px',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                cursor: 'pointer',
+                                flexShrink: 0
+                            }}
+                        >
+                            {isPlaying ? <MdPause size={24} /> : <MdPlayArrow size={24} />}
+                        </button>
+
+                        <MdMusicNote size={16} style={{ flexShrink: 0, opacity: 0.6 }} />
+
+                        <span
+                            style={{
+                                fontSize: '12px',
+                                fontVariantNumeric: 'tabular-nums',
+                                flexShrink: 0,
+                                minWidth: '32px',
+                                textAlign: 'right'
+                            }}
+                        >
+                            {formatTime(currentTime)}
+                        </span>
+
+                        <input
+                            type="range"
+                            min={0}
+                            max={duration > 0 ? duration : 1}
+                            value={Math.min(currentTime, duration > 0 ? duration : 1)}
+                            onChange={handleSeek}
+                            style={{
+                                flex: 1,
+                                height: '4px',
+                                accentColor: CssVar.contentLink,
+                                cursor: 'pointer'
+                            }}
+                        />
+
+                        <span
+                            style={{
+                                fontSize: '12px',
+                                fontVariantNumeric: 'tabular-nums',
+                                flexShrink: 0,
+                                minWidth: '32px'
+                            }}
+                        >
+                            {formatTime(duration)}
+                        </span>
+
+                        <button
+                            onClick={stop}
+                            style={{
+                                background: 'none',
+                                border: 'none',
+                                color: 'inherit',
+                                padding: '4px',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                cursor: 'pointer',
+                                flexShrink: 0
+                            }}
+                        >
+                            <MdClose size={20} />
+                        </button>
+                    </div>
+                </div>
+            )}
+        </AudioPlayerContext.Provider>
+    )
+}
+
+export const useAudioPlayer = (): AudioPlayerState => {
+    return useContext(AudioPlayerContext)
+}

--- a/app/src/contexts/MediaViewer.tsx
+++ b/app/src/contexts/MediaViewer.tsx
@@ -3,6 +3,7 @@ import { motion, useMotionValue, useTransform } from 'motion/react'
 import { animate } from 'motion'
 
 import { MdClose } from 'react-icons/md'
+import { ModelViewer } from '../components/ModelViewer'
 
 export interface MediaItem {
     mediaURL: string
@@ -13,10 +14,12 @@ export interface MediaItem {
 
 interface MediaViewerState {
     open: (medias: MediaItem[], startIndex?: number) => void
+    openModel: (src: string) => void
 }
 
 const MediaViewerContext = createContext<MediaViewerState>({
-    open: () => {}
+    open: () => {},
+    openModel: () => {}
 })
 
 interface Props {
@@ -68,7 +71,9 @@ const getMidpoint = (t1: React.Touch, t2: React.Touch) => ({
 export const MediaViewerProvider = (props: Props) => {
     const [medias, setMedias] = useState<MediaItem[]>([])
     const [currentIndex, setCurrentIndex] = useState(0)
+    const [modelSrc, setModelSrc] = useState<string | null>(null)
     const isOpen = medias.length > 0
+    const isModelOpen = modelSrc !== null
 
     // --- motion values ---
     const mvOffsetX = useMotionValue(0)
@@ -155,6 +160,7 @@ export const MediaViewerProvider = (props: Props) => {
     const close = useCallback(() => {
         setMedias([])
         setCurrentIndex(0)
+        setModelSrc(null)
         resetMotion()
     }, [resetMotion])
 
@@ -412,7 +418,7 @@ export const MediaViewerProvider = (props: Props) => {
 
     // スクロール抑制
     useEffect(() => {
-        if (isOpen) {
+        if (isOpen || isModelOpen) {
             document.body.style.overflow = 'hidden'
         } else {
             document.body.style.overflow = ''
@@ -420,7 +426,7 @@ export const MediaViewerProvider = (props: Props) => {
         return () => {
             document.body.style.overflow = ''
         }
-    }, [isOpen])
+    }, [isOpen, isModelOpen])
 
     useEffect(() => {
         gestureRef.current.gestureType = 'none'
@@ -430,7 +436,11 @@ export const MediaViewerProvider = (props: Props) => {
     const prevMedia = currentIndex > 0 ? medias[currentIndex - 1] : null
     const nextMedia = currentIndex < medias.length - 1 ? medias[currentIndex + 1] : null
 
-    const value = useMemo(() => ({ open }), [open])
+    const openModel = useCallback((src: string) => {
+        setModelSrc(src)
+    }, [])
+
+    const value = useMemo(() => ({ open, openModel }), [open, openModel])
 
     return (
         <MediaViewerContext.Provider value={value}>
@@ -630,6 +640,55 @@ export const MediaViewerProvider = (props: Props) => {
                         </div>
                     )}
                 </motion.div>
+            )}
+
+            {/* 3Dモデルビューワー */}
+            {isModelOpen && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        top: 0,
+                        left: 0,
+                        width: '100vw',
+                        height: '100dvh',
+                        backgroundColor: 'rgba(0, 0, 0, 0.9)',
+                        zIndex: 9999,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center'
+                    }}
+                >
+                    <ModelViewer
+                        src={modelSrc!}
+                        style={{
+                            backgroundColor: '#3f3f3f',
+                            width: '90vw',
+                            height: '80dvh',
+                            borderRadius: '8px'
+                        }}
+                    />
+
+                    <button
+                        onClick={() => setModelSrc(null)}
+                        style={{
+                            position: 'absolute',
+                            top: 'max(12px, env(safe-area-inset-top))',
+                            right: '12px',
+                            background: 'rgba(255, 255, 255, 0.15)',
+                            border: 'none',
+                            borderRadius: '50%',
+                            width: '40px',
+                            height: '40px',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            cursor: 'pointer',
+                            color: 'white'
+                        }}
+                    >
+                        <MdClose size={24} />
+                    </button>
+                </div>
             )}
         </MediaViewerContext.Provider>
     )

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -14,6 +14,7 @@ import { DrawerProvider } from './contexts/Drawer'
 import { OverlayProvider } from './contexts/Overlay'
 import { ComposerProvider } from './contexts/Composer'
 import { MediaViewerProvider } from './contexts/MediaViewer'
+import { AudioPlayerProvider } from './contexts/AudioPlayer'
 import { ImageCropperProvider } from './contexts/ImageCropper'
 import TickerProvider from './contexts/Ticer'
 import { ConfirmProvider } from './contexts/Confirm'
@@ -34,9 +35,11 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
                                             <ScannerProvider>
                                                 <OverlayProvider>
                                                     <MediaViewerProvider>
-                                                        <TickerProvider>
-                                                            <App />
-                                                        </TickerProvider>
+                                                        <AudioPlayerProvider>
+                                                            <TickerProvider>
+                                                                <App />
+                                                            </TickerProvider>
+                                                        </AudioPlayerProvider>
                                                     </MediaViewerProvider>
                                                 </OverlayProvider>
                                             </ScannerProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@concrnt/worldlib':
         specifier: workspace:*
         version: link:../worldlib
+      '@google/model-viewer':
+        specifier: ^4.2.0
+        version: 4.2.0(three@0.182.0)
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
@@ -687,6 +690,12 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@google/model-viewer@4.2.0':
+    resolution: {integrity: sha512-RjpAI5cLs9CdvPcMRsOs8Bea/lNmGTTyaPyl16o9Fv6Qn8VSpgBMmXFr/11yb0hTrsojp2dOACEcY77R8hVUVA==}
+    engines: {node: '>=6.0.0'}
+    peerDependencies:
+      three: ^0.182.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -731,11 +740,22 @@ packages:
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
 
+  '@lit-labs/ssr-dom-shim@1.5.1':
+    resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
+
+  '@lit/reactive-element@2.1.2':
+    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+
   '@mdx-js/react@3.1.1':
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@monogrid/gainmap-js@3.4.0':
+    resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
+    peerDependencies:
+      three: '>= 0.159.0'
 
   '@neoconfetti/react@1.0.0':
     resolution: {integrity: sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==}
@@ -1175,6 +1195,9 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1943,6 +1966,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2047,6 +2073,9 @@ packages:
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
+
+  is-promise@2.2.2:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -2159,6 +2188,9 @@ packages:
   libsodium-wrappers-sumo@0.7.16:
     resolution: {integrity: sha512-gR0JEFPeN3831lB9+ogooQk0KH4K5LSMIO5Prd5Q5XYR2wHFtZfPg0eP7t1oJIWq+UIzlU4WVeBxZ97mt28tXw==}
 
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
     engines: {node: '>=20.17'}
@@ -2167,6 +2199,15 @@ packages:
   listr2@9.0.5:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
+
+  lit-element@4.2.2:
+    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
+
+  lit-html@3.3.2:
+    resolution: {integrity: sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==}
+
+  lit@3.3.2:
+    resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -2403,6 +2444,9 @@ packages:
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
+
+  promise-worker-transferable@1.0.4:
+    resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -2726,6 +2770,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  three@0.182.0:
+    resolution: {integrity: sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -3274,6 +3321,12 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@google/model-viewer@4.2.0(three@0.182.0)':
+    dependencies:
+      '@monogrid/gainmap-js': 3.4.0(three@0.182.0)
+      lit: 3.3.2
+      three: 0.182.0
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -3314,11 +3367,22 @@ snapshots:
 
   '@jsdevtools/ono@7.1.3': {}
 
+  '@lit-labs/ssr-dom-shim@1.5.1': {}
+
+  '@lit/reactive-element@2.1.2':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.1
+
   '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
       react: 19.2.4
+
+  '@monogrid/gainmap-js@3.4.0(three@0.182.0)':
+    dependencies:
+      promise-worker-transferable: 1.0.4
+      three: 0.182.0
 
   '@neoconfetti/react@1.0.0': {}
 
@@ -3713,6 +3777,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.6': {}
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
 
@@ -4642,6 +4708,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -4746,6 +4814,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-promise@2.2.2: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -4865,6 +4935,10 @@ snapshots:
     dependencies:
       libsodium-sumo: 0.7.16
 
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
   lint-staged@16.4.0:
     dependencies:
       commander: 14.0.3
@@ -4882,6 +4956,22 @@ snapshots:
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
+
+  lit-element@4.2.2:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.1
+      '@lit/reactive-element': 2.1.2
+      lit-html: 3.3.2
+
+  lit-html@3.3.2:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.2:
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit-element: 4.2.2
+      lit-html: 3.3.2
 
   locate-path@6.0.0:
     dependencies:
@@ -5104,6 +5194,11 @@ snapshots:
       react-is: 17.0.2
 
   prismjs@1.30.0: {}
+
+  promise-worker-transferable@1.0.4:
+    dependencies:
+      is-promise: 2.2.2
+      lie: 3.3.0
 
   prop-types@15.8.1:
     dependencies:
@@ -5521,6 +5616,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  three@0.182.0: {}
 
   tiny-invariant@1.3.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
       '@emotion/is-prop-valid':
         specifier: ^1.4.0
         version: 1.4.0
+      '@google/model-viewer':
+        specifier: ^4.2.0
+        version: 4.2.0(three@0.182.0)
       '@rjsf/core':
         specifier: ^6.4.2
         version: 6.4.2(@rjsf/utils@6.4.2(react@19.2.4))(react@19.2.4)

--- a/web/package.json
+++ b/web/package.json
@@ -10,11 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@emotion/is-prop-valid": "^1.4.0",
     "@concrnt/cfm": "^0.0.0",
     "@concrnt/client": "workspace:*",
     "@concrnt/ui": "workspace:*",
     "@concrnt/worldlib": "workspace:*",
+    "@emotion/is-prop-valid": "^1.4.0",
+    "@google/model-viewer": "^4.2.0",
     "@rjsf/core": "^6.4.2",
     "@rjsf/utils": "^6.4.2",
     "@rjsf/validator-ajv8": "^6.4.2",

--- a/web/src/components/ModelViewer.tsx
+++ b/web/src/components/ModelViewer.tsx
@@ -1,0 +1,42 @@
+import { CSSProperties, useEffect, useState } from 'react'
+
+interface ModelViewerProps {
+    src: string
+    style?: CSSProperties
+}
+
+export const ModelViewer = (props: ModelViewerProps) => {
+    const [loaded, setLoaded] = useState(false)
+
+    useEffect(() => {
+        import('@google/model-viewer')
+            .then(() => setLoaded(true))
+            .catch(() => console.warn('model-viewer failed to load'))
+    }, [])
+
+    if (!loaded) {
+        return (
+            <div style={{ ...props.style, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'rgba(255,255,255,0.6)' }}>
+                Loading...
+            </div>
+        )
+    }
+
+    return <model-viewer src={props.src} autoplay camera-controls style={props.style} />
+}
+
+declare module 'react' {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace JSX {
+        interface IntrinsicElements {
+            'model-viewer': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+                src: string
+                alt?: string
+                'camera-controls'?: boolean
+                'auto-rotate'?: boolean
+                ar?: boolean
+                autoplay?: boolean
+            }
+        }
+    }
+}

--- a/web/src/components/message/MediaMessage.tsx
+++ b/web/src/components/message/MediaMessage.tsx
@@ -2,8 +2,10 @@ import { MessageProps } from './types'
 import { MediaMessageSchema } from '@concrnt/worldlib'
 
 import { Avatar, CfmRenderer, CssVar } from '@concrnt/ui'
+import { MdPlayCircle, MdStop, MdViewInAr } from 'react-icons/md'
 
 import { useMediaViewer } from '../../contexts/MediaViewer'
+import { useAudioPlayer } from '../../contexts/AudioPlayer'
 import { MessageActions } from './MessageActions'
 import { MessageLayout } from './MessageLayout'
 import { TimeDiff } from '../TimeDiff'
@@ -13,6 +15,7 @@ import { useNavigate } from 'react-router-dom'
 export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
     const navigate = useNavigate()
     const mediaViewer = useMediaViewer()
+    const audioPlayer = useAudioPlayer()
 
     const message = props.message
 
@@ -66,10 +69,18 @@ export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
                             }}
                             onClick={(e) => {
                                 e.stopPropagation()
-                                const imageMedias = medias.filter((m) => m.mediaType.startsWith('image/'))
-                                const viewerIndex = imageMedias.findIndex((m) => m.mediaURL === media.mediaURL)
                                 if (media.mediaType.startsWith('image/')) {
+                                    const imageMedias = medias.filter((m) => m.mediaType.startsWith('image/'))
+                                    const viewerIndex = imageMedias.findIndex((m) => m.mediaURL === media.mediaURL)
                                     mediaViewer.open(imageMedias, viewerIndex >= 0 ? viewerIndex : 0)
+                                } else if (media.mediaType.startsWith('audio/')) {
+                                    if (audioPlayer.nowPlaying === media.mediaURL) {
+                                        audioPlayer.stop()
+                                    } else {
+                                        audioPlayer.play(media.mediaURL)
+                                    }
+                                } else if (media.mediaType.startsWith('model/')) {
+                                    mediaViewer.openModel(media.mediaURL)
                                 }
                             }}
                         >
@@ -94,6 +105,43 @@ export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
                                         maxHeight: '300px'
                                     }}
                                 />
+                            ) : media.mediaType.startsWith('audio/') ? (
+                                <div
+                                    style={{
+                                        width: '100%',
+                                        height: medias.length === 1 ? '80px' : '100%',
+                                        minHeight: '80px',
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        backgroundColor: 'rgba(0, 0, 0, 0.15)',
+                                        cursor: 'pointer'
+                                    }}
+                                >
+                                    {audioPlayer.nowPlaying === media.mediaURL ? (
+                                        <MdStop size={48} style={{ color: 'rgba(255, 255, 255, 0.8)' }} />
+                                    ) : (
+                                        <MdPlayCircle size={48} style={{ color: 'rgba(255, 255, 255, 0.8)' }} />
+                                    )}
+                                </div>
+                            ) : media.mediaType.startsWith('model/') ? (
+                                <div
+                                    style={{
+                                        width: '100%',
+                                        height: medias.length === 1 ? '120px' : '100%',
+                                        minHeight: '100px',
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        backgroundColor: 'rgba(0, 0, 0, 0.15)',
+                                        cursor: 'pointer',
+                                        gap: '8px'
+                                    }}
+                                >
+                                    <MdViewInAr size={48} style={{ color: 'rgba(255, 255, 255, 0.8)' }} />
+                                    <span style={{ color: 'rgba(255, 255, 255, 0.6)', fontSize: '12px' }}>3D Model</span>
+                                </div>
                             ) : (
                                 <div>Unsupported media type: {media.mediaType}</div>
                             )}

--- a/web/src/contexts/AudioPlayer.tsx
+++ b/web/src/contexts/AudioPlayer.tsx
@@ -1,0 +1,251 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { MdPlayArrow, MdPause, MdClose, MdMusicNote } from 'react-icons/md'
+import { CssVar } from '../types/Theme'
+
+export interface AudioPlayerState {
+    nowPlaying: string | null
+    play: (src: string) => void
+    stop: () => void
+}
+
+const AudioPlayerContext = createContext<AudioPlayerState>({
+    nowPlaying: null,
+    play: () => {},
+    stop: () => {}
+})
+
+interface Props {
+    children: React.ReactNode
+}
+
+const formatTime = (seconds: number): string => {
+    const safe = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0
+    const m = Math.floor(safe / 60)
+    const s = safe % 60
+    return `${m}:${String(s).padStart(2, '0')}`
+}
+
+export const AudioPlayerProvider = (props: Props) => {
+    const audioRef = useRef<HTMLAudioElement | null>(null)
+    const [src, setSrc] = useState<string | null>(null)
+    const [isPlaying, setIsPlaying] = useState(false)
+    const [duration, setDuration] = useState(0)
+    const [currentTime, setCurrentTime] = useState(0)
+
+    useEffect(() => {
+        const audio = new Audio()
+        audio.preload = 'metadata'
+        audioRef.current = audio
+
+        const onPlay = () => setIsPlaying(true)
+        const onPause = () => setIsPlaying(false)
+        const onEnded = () => {
+            setIsPlaying(false)
+            setCurrentTime(0)
+        }
+        const onLoadedMetadata = () => {
+            if (Number.isFinite(audio.duration)) {
+                setDuration(audio.duration)
+            }
+        }
+        const onDurationChange = () => {
+            if (Number.isFinite(audio.duration)) {
+                setDuration(audio.duration)
+            }
+        }
+        const onTimeUpdate = () => {
+            setCurrentTime(audio.currentTime)
+        }
+
+        audio.addEventListener('play', onPlay)
+        audio.addEventListener('pause', onPause)
+        audio.addEventListener('ended', onEnded)
+        audio.addEventListener('loadedmetadata', onLoadedMetadata)
+        audio.addEventListener('durationchange', onDurationChange)
+        audio.addEventListener('timeupdate', onTimeUpdate)
+
+        return () => {
+            audio.removeEventListener('play', onPlay)
+            audio.removeEventListener('pause', onPause)
+            audio.removeEventListener('ended', onEnded)
+            audio.removeEventListener('loadedmetadata', onLoadedMetadata)
+            audio.removeEventListener('durationchange', onDurationChange)
+            audio.removeEventListener('timeupdate', onTimeUpdate)
+            audio.pause()
+            audio.removeAttribute('src')
+            audio.load()
+        }
+    }, [])
+
+    const play = useCallback(
+        (nextSrc: string) => {
+            const audio = audioRef.current
+            if (!audio) return
+
+            if (src === nextSrc) {
+                if (isPlaying) {
+                    audio.pause()
+                } else {
+                    void audio.play()
+                }
+                return
+            }
+
+            audio.src = nextSrc
+            audio.currentTime = 0
+            setCurrentTime(0)
+            setDuration(0)
+            setSrc(nextSrc)
+            void audio.play().catch(() => setIsPlaying(false))
+        },
+        [src, isPlaying]
+    )
+
+    const stop = useCallback(() => {
+        const audio = audioRef.current
+        if (audio) {
+            audio.pause()
+            audio.removeAttribute('src')
+            audio.load()
+        }
+        setSrc(null)
+        setIsPlaying(false)
+        setCurrentTime(0)
+        setDuration(0)
+    }, [])
+
+    const togglePlay = useCallback(() => {
+        const audio = audioRef.current
+        if (!audio || !src) return
+        if (isPlaying) {
+            audio.pause()
+        } else {
+            void audio.play()
+        }
+    }, [src, isPlaying])
+
+    const handleSeek = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const audio = audioRef.current
+            if (!audio) return
+            const time = Number(e.target.value)
+            audio.currentTime = time
+            setCurrentTime(time)
+        },
+        []
+    )
+
+    const value = useMemo(() => ({ nowPlaying: src, play, stop }), [src, play, stop])
+
+    return (
+        <AudioPlayerContext.Provider value={value}>
+            {props.children}
+
+            {src && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        bottom: '16px',
+                        left: '50%',
+                        transform: 'translateX(-50%)',
+                        zIndex: 9000,
+                        width: '100%',
+                        maxWidth: '600px',
+                        padding: '0 8px',
+                        boxSizing: 'border-box'
+                    }}
+                >
+                    <div
+                        style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '8px',
+                            padding: '8px 12px',
+                            borderRadius: '12px',
+                            backgroundColor: CssVar.uiBackground,
+                            color: CssVar.uiText,
+                            boxShadow: '0 2px 12px rgba(0,0,0,0.25)'
+                        }}
+                    >
+                        <button
+                            onClick={togglePlay}
+                            style={{
+                                background: 'none',
+                                border: 'none',
+                                color: 'inherit',
+                                padding: '4px',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                cursor: 'pointer',
+                                flexShrink: 0
+                            }}
+                        >
+                            {isPlaying ? <MdPause size={24} /> : <MdPlayArrow size={24} />}
+                        </button>
+
+                        <MdMusicNote size={16} style={{ flexShrink: 0, opacity: 0.6 }} />
+
+                        <span
+                            style={{
+                                fontSize: '12px',
+                                fontVariantNumeric: 'tabular-nums',
+                                flexShrink: 0,
+                                minWidth: '32px',
+                                textAlign: 'right'
+                            }}
+                        >
+                            {formatTime(currentTime)}
+                        </span>
+
+                        <input
+                            type="range"
+                            min={0}
+                            max={duration > 0 ? duration : 1}
+                            value={Math.min(currentTime, duration > 0 ? duration : 1)}
+                            onChange={handleSeek}
+                            style={{
+                                flex: 1,
+                                height: '4px',
+                                accentColor: CssVar.contentLink,
+                                cursor: 'pointer'
+                            }}
+                        />
+
+                        <span
+                            style={{
+                                fontSize: '12px',
+                                fontVariantNumeric: 'tabular-nums',
+                                flexShrink: 0,
+                                minWidth: '32px'
+                            }}
+                        >
+                            {formatTime(duration)}
+                        </span>
+
+                        <button
+                            onClick={stop}
+                            style={{
+                                background: 'none',
+                                border: 'none',
+                                color: 'inherit',
+                                padding: '4px',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                cursor: 'pointer',
+                                flexShrink: 0
+                            }}
+                        >
+                            <MdClose size={20} />
+                        </button>
+                    </div>
+                </div>
+            )}
+        </AudioPlayerContext.Provider>
+    )
+}
+
+export const useAudioPlayer = (): AudioPlayerState => {
+    return useContext(AudioPlayerContext)
+}

--- a/web/src/contexts/MediaViewer.tsx
+++ b/web/src/contexts/MediaViewer.tsx
@@ -3,6 +3,7 @@ import { motion, useMotionValue, useTransform } from 'motion/react'
 import { animate } from 'motion'
 
 import { MdClose } from 'react-icons/md'
+import { ModelViewer } from '../components/ModelViewer'
 
 export interface MediaItem {
     mediaURL: string
@@ -13,10 +14,12 @@ export interface MediaItem {
 
 interface MediaViewerState {
     open: (medias: MediaItem[], startIndex?: number) => void
+    openModel: (src: string) => void
 }
 
 const MediaViewerContext = createContext<MediaViewerState>({
-    open: () => {}
+    open: () => {},
+    openModel: () => {}
 })
 
 interface Props {
@@ -68,7 +71,9 @@ const getMidpoint = (t1: React.Touch, t2: React.Touch) => ({
 export const MediaViewerProvider = (props: Props) => {
     const [medias, setMedias] = useState<MediaItem[]>([])
     const [currentIndex, setCurrentIndex] = useState(0)
+    const [modelSrc, setModelSrc] = useState<string | null>(null)
     const isOpen = medias.length > 0
+    const isModelOpen = modelSrc !== null
 
     // --- motion values ---
     const mvOffsetX = useMotionValue(0)
@@ -155,6 +160,7 @@ export const MediaViewerProvider = (props: Props) => {
     const close = useCallback(() => {
         setMedias([])
         setCurrentIndex(0)
+        setModelSrc(null)
         resetMotion()
     }, [resetMotion])
 
@@ -412,7 +418,7 @@ export const MediaViewerProvider = (props: Props) => {
 
     // スクロール抑制
     useEffect(() => {
-        if (isOpen) {
+        if (isOpen || isModelOpen) {
             document.body.style.overflow = 'hidden'
         } else {
             document.body.style.overflow = ''
@@ -420,7 +426,7 @@ export const MediaViewerProvider = (props: Props) => {
         return () => {
             document.body.style.overflow = ''
         }
-    }, [isOpen])
+    }, [isOpen, isModelOpen])
 
     useEffect(() => {
         gestureRef.current.gestureType = 'none'
@@ -430,7 +436,11 @@ export const MediaViewerProvider = (props: Props) => {
     const prevMedia = currentIndex > 0 ? medias[currentIndex - 1] : null
     const nextMedia = currentIndex < medias.length - 1 ? medias[currentIndex + 1] : null
 
-    const value = useMemo(() => ({ open }), [open])
+    const openModel = useCallback((src: string) => {
+        setModelSrc(src)
+    }, [])
+
+    const value = useMemo(() => ({ open, openModel }), [open, openModel])
 
     return (
         <MediaViewerContext.Provider value={value}>
@@ -630,6 +640,54 @@ export const MediaViewerProvider = (props: Props) => {
                         </div>
                     )}
                 </motion.div>
+            )}
+
+            {isModelOpen && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        top: 0,
+                        left: 0,
+                        width: '100vw',
+                        height: '100dvh',
+                        backgroundColor: 'rgba(0, 0, 0, 0.9)',
+                        zIndex: 9999,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center'
+                    }}
+                >
+                    <ModelViewer
+                        src={modelSrc!}
+                        style={{
+                            backgroundColor: '#3f3f3f',
+                            width: '90vw',
+                            height: '80dvh',
+                            borderRadius: '8px'
+                        }}
+                    />
+
+                    <button
+                        onClick={() => setModelSrc(null)}
+                        style={{
+                            position: 'absolute',
+                            top: 'max(12px, env(safe-area-inset-top))',
+                            right: '12px',
+                            background: 'rgba(255, 255, 255, 0.15)',
+                            border: 'none',
+                            borderRadius: '50%',
+                            width: '40px',
+                            height: '40px',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            cursor: 'pointer',
+                            color: 'white'
+                        }}
+                    >
+                        <MdClose size={24} />
+                    </button>
+                </div>
             )}
         </MediaViewerContext.Provider>
     )

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -12,6 +12,7 @@ import { SelectProvider } from './contexts/Select'
 import { DrawerProvider } from './contexts/Drawer'
 import { ComposerProvider } from './contexts/Composer'
 import { MediaViewerProvider } from './contexts/MediaViewer'
+import { AudioPlayerProvider } from './contexts/AudioPlayer'
 import { ImageCropperProvider } from './contexts/ImageCropper'
 import TickerProvider from './contexts/Ticer'
 import { ConfirmProvider } from './contexts/Confirm'
@@ -61,6 +62,7 @@ const AuthedRoutes = () => (
                     <SelectProvider>
                         <ComposerProvider>
                                     <MediaViewerProvider>
+                                        <AudioPlayerProvider>
                                         <TickerProvider>
                                             <Routes>
                                                 <Route path="/" element={<AppShell />}>
@@ -88,6 +90,7 @@ const AuthedRoutes = () => (
                                                 </Route>
                                             </Routes>
                                         </TickerProvider>
+                                        </AudioPlayerProvider>
                                     </MediaViewerProvider>
                         </ComposerProvider>
                     </SelectProvider>


### PR DESCRIPTION
resolve #62 

## 概要
 
旧コンカレアプリ（concrnt.world）基準でメディアビューワーが扱えるメディア種別を揃えました。
従来 `image/*` と `video/*` のみ対応していたところに、`audio/*` と `model/*` のサポートを追加しています。
 
## 変更内容
 
### `audio/*` 対応
 
- **AudioPlayerコンテキスト** (`contexts/AudioPlayer.tsx`) を新規作成
  - HTMLAudioElementによるシングルトン再生管理（同時再生は1つだけ）
  - play / pause / stop / シーク操作に対応
- **MediaMessage** にオーディオカードUIを追加
  - 再生/停止アイコン（MdPlayCircle / MdStop）のオーバーレイ表示
  - タップで再生開始、再タップで停止
- **ミニプレーヤーバー**
  - 再生中は画面下部（タブバーの上）にフローティングバーが出現
  - 再生/一時停止・シークバー・経過時間/総時間・閉じるボタン
### `model/*` 対応
 
- **ModelViewerコンポーネント** (`components/ModelViewer.tsx`) を新規作成しましたがこれが上手く行ってないっぽいです。
  - `@google/model-viewer` を dynamic import でlazy-load
  - camera-controls / autoplay 対応
- **MediaMessage** に3DモデルカードUIを追加
  - MdViewInAr アイコン + 「3D Model」テキストのプレースホルダー表示
  - タップで全画面3Dビューワーが開く
- **MediaViewer** に `openModel` メソッドを追加
  - 全画面モーダルで `<model-viewer>` をレンダリング
## 変更ファイル一覧
 
| 区分 | ファイル |
|---|---|
| 新規 | `app/src/contexts/AudioPlayer.tsx` |
| 新規 | `app/src/components/ModelViewer.tsx` |
| 変更 | `app/src/main.tsx` |
| 変更 | `app/src/contexts/MediaViewer.tsx` |
| 変更 | `app/src/components/message/MediaMessage.tsx` |
 
## 備考
 
- `@google/model-viewer` を依存に追加しています（`pnpm --filter world-app add @google/model-viewer`）
- model-viewer は Tauri WebView 上での動作が未検証のため、環境によっては追加調整が必要になる可能性があります
 