### PR TITLE
絵文字の表示機能を実装しました

### DIFF
--- a/app/src/components/Composer.tsx
+++ b/app/src/components/Composer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Button, Divider, IconButton, useTheme, Text } from '@concrnt/ui'
+import { Button, Divider, IconButton, useTheme, Text, CfmRenderer } from '@concrnt/ui'
 import { useClient } from '../contexts/Client'
 import { AnimatePresence, motion } from 'motion/react'
 import { isNonNullOrUndefined, Message, Schemas, semantics } from '@concrnt/worldlib'
@@ -37,6 +37,7 @@ export const Composer = (props: Props) => {
     const [postHome, setPostHome] = useState<boolean>(true)
     const [mediaDrafts, setMediaDrafts] = useState<MediaDraft[]>([])
     const [uploading, setUploading] = useState<boolean>(false)
+    const [emojiDict, setEmojiDict] = useState<Record<string, { imageURL: string }>>({})
 
     const fileInputRef = useRef<HTMLInputElement>(null)
     const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -140,7 +141,8 @@ export const Composer = (props: Props) => {
                         schema: Schemas.replyMessage,
                         value: {
                             body: draft,
-                            replyToMessageId: props.targetMessage.uri
+                            replyToMessageId: props.targetMessage.uri,
+                            emojis: emojiDict
                         },
                         author: client.ccid,
                         distributes,
@@ -231,7 +233,8 @@ export const Composer = (props: Props) => {
                             schema: Schemas.mediaMessage,
                             value: {
                                 body: draft,
-                                medias: uploadedMedias
+                                medias: uploadedMedias,
+                                emojis: emojiDict
                             },
                             author: client.ccid,
                             distributes,
@@ -243,7 +246,8 @@ export const Composer = (props: Props) => {
                             key: newPostUri,
                             schema: Schemas.markdownMessage,
                             value: {
-                                body: draft
+                                body: draft,
+                                emojis: emojiDict
                             },
                             author: client.ccid,
                             distributes,
@@ -268,6 +272,7 @@ export const Composer = (props: Props) => {
         <AnimatePresence
             onExitComplete={() => {
                 setDraft('')
+                setEmojiDict({})
                 mediaDrafts
                     .map((media) => media.previewUrl)
                     .filter(isNonNullOrUndefined)
@@ -398,6 +403,23 @@ export const Composer = (props: Props) => {
                                 </div>
                             )}
 
+                            {/* テキストプレビュー（絵文字等のレンダリング確認用） */}
+                            {props.mode !== 'reroute' && draft.length > 0 && (
+                                <>
+                                    <div style={{ borderTop: '1px dashed', borderColor: CssVar.divider }} />
+                                    <div
+                                        style={{
+                                            fontSize: '0.85rem',
+                                            opacity: 0.8,
+                                            maxHeight: '80px',
+                                            overflowY: 'auto'
+                                        }}
+                                    >
+                                        <CfmRenderer messagebody={draft} emojiDict={emojiDict} />
+                                    </div>
+                                </>
+                            )}
+
                             {/* 画像プレビュー */}
                             {mediaDrafts.length > 0 && (
                                 <div
@@ -505,6 +527,10 @@ export const Composer = (props: Props) => {
                                                     } else {
                                                         setDraft((prev) => prev + `:${emoji.shortcode}:`)
                                                     }
+                                                    setEmojiDict((prev) => ({
+                                                        ...prev,
+                                                        [emoji.shortcode]: { imageURL: emoji.imageURL }
+                                                    }))
                                                 })
                                             }}
                                         >

--- a/app/src/components/message/MarkdownMessage.tsx
+++ b/app/src/components/message/MarkdownMessage.tsx
@@ -43,7 +43,7 @@ export const MarkdownMessage = (props: MessageProps<MarkdownMessageSchema>) => {
             }
             headerRight={<TimeDiff date={message.createdAt} />}
         >
-            <CfmRenderer messagebody={message.value.body} emojiDict={{}} />
+            <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
             <div
                 style={{
                     display: 'flex',

--- a/app/src/components/message/MediaMessage.tsx
+++ b/app/src/components/message/MediaMessage.tsx
@@ -50,7 +50,9 @@ export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
             }
             headerRight={<TimeDiff date={message.createdAt} />}
         >
-            {message.value.body && <CfmRenderer messagebody={message.value.body} emojiDict={{}} />}
+            {message.value.body && (
+                <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
+            )}
 
             {medias.length > 0 && (
                 <div

--- a/app/src/components/message/OnelineMessage.tsx
+++ b/app/src/components/message/OnelineMessage.tsx
@@ -37,7 +37,7 @@ export const OnelineMessage = (props: MessageProps<MarkdownMessageSchema>) => {
                 push(<PostView uri={message.uri} />)
             }}
         >
-            <CfmRenderer messagebody={message.value.body} emojiDict={{}} />
+            <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
             <div style={{ flex: 1 }} />
             <IconButton
                 onClick={(e) => {

--- a/app/src/components/message/ReplyMessage.tsx
+++ b/app/src/components/message/ReplyMessage.tsx
@@ -50,7 +50,7 @@ export const ReplyMessage = (props: MessageProps<ReplyMessageSchema>) => {
                 }
                 headerRight={<TimeDiff date={props.message.createdAt} />}
             >
-                <CfmRenderer messagebody={props.message.value.body} emojiDict={{}} />
+                <CfmRenderer messagebody={props.message.value.body} emojiDict={props.message.value.emojis ?? {}} />
                 <div
                     style={{
                         display: 'flex',

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Button, Divider, IconButton, useTheme, Text } from '@concrnt/ui'
+import { Button, Divider, IconButton, useTheme, Text, CfmRenderer } from '@concrnt/ui'
 import { useClient } from '../contexts/Client'
 import { AnimatePresence, motion } from 'motion/react'
 import { isNonNullOrUndefined, Message, Schemas, semantics } from '@concrnt/worldlib'
@@ -12,6 +12,8 @@ import { MdImage, MdClose } from 'react-icons/md'
 import { uploadImage } from '../utils/uploadImage'
 import { hapticSuccess } from '../utils/haptics'
 import { MdSend } from 'react-icons/md'
+import { MdEmojiEmotions } from 'react-icons/md'
+import { useEmojiPicker, Emoji } from '../contexts/EmojiPicker'
 import { MdOutlineUploadFile } from "react-icons/md";
 
 interface MediaDraft {
@@ -35,9 +37,12 @@ export const Composer = (props: Props) => {
     const [postHome, setPostHome] = useState<boolean>(true)
     const [mediaDrafts, setMediaDrafts] = useState<MediaDraft[]>([])
     const [uploading, setUploading] = useState<boolean>(false)
+    const [emojiDict, setEmojiDict] = useState<Record<string, { imageURL: string }>>({})
 
     const fileInputRef = useRef<HTMLInputElement>(null)
+    const textareaRef = useRef<HTMLTextAreaElement>(null)
     const theme = useTheme()
+    const emojiPicker = useEmojiPicker()
 
     const [viewportHeight, setViewportHeight] = useLocalStorage<number>(
         'composerViewportHeight',
@@ -134,7 +139,8 @@ export const Composer = (props: Props) => {
                         schema: Schemas.replyMessage,
                         value: {
                             body: draft,
-                            replyToMessageId: props.targetMessage.uri
+                            replyToMessageId: props.targetMessage.uri,
+                            emojis: emojiDict
                         },
                         author: client.ccid,
                         distributes,
@@ -225,7 +231,8 @@ export const Composer = (props: Props) => {
                             schema: Schemas.mediaMessage,
                             value: {
                                 body: draft,
-                                medias: uploadedMedias
+                                medias: uploadedMedias,
+                                emojis: emojiDict
                             },
                             author: client.ccid,
                             distributes,
@@ -237,7 +244,8 @@ export const Composer = (props: Props) => {
                             key: newPostUri,
                             schema: Schemas.markdownMessage,
                             value: {
-                                body: draft
+                                body: draft,
+                                emojis: emojiDict
                             },
                             author: client.ccid,
                             distributes,
@@ -262,6 +270,7 @@ export const Composer = (props: Props) => {
         <AnimatePresence
             onExitComplete={() => {
                 setDraft('')
+                setEmojiDict({})
                 mediaDrafts.map((media) => media.previewUrl).filter(isNonNullOrUndefined)
                     .forEach((url) => URL.revokeObjectURL(url))
                 setMediaDrafts([])
@@ -370,6 +379,7 @@ export const Composer = (props: Props) => {
                                     }}
                                 >
                                     <textarea
+                                        ref={textareaRef}
                                         autoFocus
                                         value={draft}
                                         placeholder={getPlaceholder()}
@@ -387,6 +397,23 @@ export const Composer = (props: Props) => {
                                         }}
                                     />
                                 </div>
+                            )}
+
+                            {/* テキストプレビュー（絵文字等のレンダリング確認用） */}
+                            {props.mode !== 'reroute' && draft.length > 0 && (
+                                <>
+                                    <div style={{ borderTop: '1px dashed', borderColor: CssVar.divider }} />
+                                    <div
+                                        style={{
+                                            fontSize: '0.85rem',
+                                            opacity: 0.8,
+                                            maxHeight: '80px',
+                                            overflowY: 'auto'
+                                        }}
+                                    >
+                                        <CfmRenderer messagebody={draft} emojiDict={emojiDict} />
+                                    </div>
+                                </>
                             )}
 
                             {/* 画像プレビュー */}
@@ -476,6 +503,32 @@ export const Composer = (props: Props) => {
                                     {props.mode === 'normal' && (
                                         <IconButton onClick={() => fileInputRef.current?.click()}>
                                             <MdImage size={24} />
+                                        </IconButton>
+                                    )}
+                                    {/* 絵文字ピッカーボタン（リルート以外） */}
+                                    {props.mode !== 'reroute' && (
+                                        <IconButton
+                                            onClick={() => {
+                                                emojiPicker.open((emoji: Emoji) => {
+                                                    const ta = textareaRef.current
+                                                    if (ta) {
+                                                        const start = ta.selectionStart
+                                                        const end = ta.selectionEnd
+                                                        const insert = `:${emoji.shortcode}:`
+                                                        const newDraft =
+                                                            draft.slice(0, start) + insert + draft.slice(end)
+                                                        setDraft(newDraft)
+                                                    } else {
+                                                        setDraft((prev) => prev + `:${emoji.shortcode}:`)
+                                                    }
+                                                    setEmojiDict((prev) => ({
+                                                        ...prev,
+                                                        [emoji.shortcode]: { imageURL: emoji.imageURL }
+                                                    }))
+                                                })
+                                            }}
+                                        >
+                                            <MdEmojiEmotions size={24} />
                                         </IconButton>
                                     )}
                                 </div>

--- a/web/src/components/message/MarkdownMessage.tsx
+++ b/web/src/components/message/MarkdownMessage.tsx
@@ -40,7 +40,7 @@ export const MarkdownMessage = (props: MessageProps<MarkdownMessageSchema>) => {
             }
             headerRight={<TimeDiff date={message.createdAt} />}
         >
-            <CfmRenderer messagebody={message.value.body} emojiDict={{}} />
+            <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
             <div
                 style={{
                     display: 'flex',

--- a/web/src/components/message/MediaMessage.tsx
+++ b/web/src/components/message/MediaMessage.tsx
@@ -47,7 +47,7 @@ export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
             }
             headerRight={<TimeDiff date={message.createdAt} />}
         >
-            {message.value.body && <CfmRenderer messagebody={message.value.body} emojiDict={{}} />}
+            {message.value.body && <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />}
 
             {medias.length > 0 && (
                 <div

--- a/web/src/components/message/OnelineMessage.tsx
+++ b/web/src/components/message/OnelineMessage.tsx
@@ -34,7 +34,7 @@ export const OnelineMessage = (props: MessageProps<MarkdownMessageSchema>) => {
                 navigate('/post/' + encodeURIComponent(message.uri))
             }}
         >
-            <CfmRenderer messagebody={message.value.body} emojiDict={{}} />
+            <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
             <div style={{ flex: 1 }} />
             <IconButton
                 onClick={(e) => {

--- a/web/src/components/message/ReplyMessage.tsx
+++ b/web/src/components/message/ReplyMessage.tsx
@@ -47,7 +47,7 @@ export const ReplyMessage = (props: MessageProps<ReplyMessageSchema>) => {
                 }
                 headerRight={<TimeDiff date={props.message.createdAt} />}
             >
-                <CfmRenderer messagebody={props.message.value.body} emojiDict={{}} />
+                <CfmRenderer messagebody={props.message.value.body} emojiDict={props.message.value.emojis ?? {}} />
                 <div
                     style={{
                         display: 'flex',

--- a/web/src/contexts/EmojiPicker.tsx
+++ b/web/src/contexts/EmojiPicker.tsx
@@ -1,0 +1,493 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { AnimatePresence, motion } from 'motion/react'
+import { CssVar } from '../types/Theme'
+import { useLocalStorage } from '../hooks/useLocalStorage'
+import { MdAccessTime, MdSearch, MdClose } from 'react-icons/md'
+import { IconButton } from '@concrnt/ui'
+
+// ---- Types ----
+
+export interface Emoji {
+    shortcode: string
+    imageURL: string
+    keywords?: string
+}
+
+export interface RawEmojiPackage {
+    name: string
+    iconURL: string
+    emojis: Emoji[]
+}
+
+export interface EmojiPackage extends RawEmojiPackage {
+    packageURL: string
+    fetchedAt: Date
+}
+
+// ---- Constants ----
+
+const TWEMOJI_URL = 'https://gist.githubusercontent.com/totegamma/6e1a047f54960f6bb7b946064664d793/raw/twemoji.json'
+const COLS = 7
+
+// ---- Context ----
+
+export interface EmojiPickerState {
+    open: (onSelected: (emoji: Emoji) => void) => void
+    close: () => void
+    search: (input: string, limit?: number) => Emoji[]
+    packages: EmojiPackage[]
+}
+
+const EmojiPickerContext = createContext<EmojiPickerState | undefined>(undefined)
+
+interface Props {
+    children: React.ReactNode
+}
+
+export const EmojiPickerProvider = (props: Props) => {
+    const onSelectedRef = useRef<((emoji: Emoji) => void) | null>(null)
+    const [isOpen, setIsOpen] = useState(false)
+
+    const [frequentEmojis, setFrequentEmojis] = useLocalStorage<Emoji[]>('emojiPicker:frequent', [])
+    const [query, setQuery] = useState('')
+    const [activeTab, setActiveTab] = useState(0)
+
+    // キャッシュからの同期読み込みはuseState初期化子で行う（useEffect内の同期setStateを避ける）
+    const [emojiPackages, setEmojiPackages] = useState<EmojiPackage[]>(() => {
+        const pkgs: EmojiPackage[] = []
+        for (const url of [TWEMOJI_URL]) {
+            const cacheKey = `emojiPackage:${url}`
+            const cache = localStorage.getItem(cacheKey)
+            if (cache) {
+                try {
+                    pkgs.push(JSON.parse(cache))
+                } catch {
+                    localStorage.removeItem(cacheKey)
+                }
+            }
+        }
+        return pkgs
+    })
+    const [allEmojis, setAllEmojis] = useState<Emoji[]>(() => emojiPackages.flatMap((pkg) => pkg.emojis))
+
+    const gridRef = useRef<HTMLDivElement>(null)
+
+    // ---- Emoji package loading ----
+    // TODO: usePreference実装後に emojiPackageURLs を設定から取得する
+    const emojiPackageURLs = useMemo(() => [TWEMOJI_URL], [])
+
+    // キャッシュにないパッケージだけネットワークから取得
+    useEffect(() => {
+        let unmounted = false
+
+        emojiPackageURLs.forEach((url) => {
+            const cacheKey = `emojiPackage:${url}`
+            // キャッシュ済みならuseState初期化子で読み込み済み → スキップ
+            if (localStorage.getItem(cacheKey)) return
+
+            fetch(url, { signal: AbortSignal.timeout(5000) })
+                .then((res) => res.json())
+                .then((raw: RawEmojiPackage) => {
+                    const pkg: EmojiPackage = {
+                        ...raw,
+                        packageURL: url,
+                        fetchedAt: new Date()
+                    }
+                    if (!unmounted) {
+                        setEmojiPackages((prev) => [...prev, pkg])
+                        setAllEmojis((prev) => [...prev, ...pkg.emojis])
+                        localStorage.setItem(cacheKey, JSON.stringify(pkg))
+                    }
+                })
+                .catch((e) => {
+                    console.error('Failed to fetch emoji package:', url, e)
+                })
+        })
+
+        return () => {
+            unmounted = true
+        }
+    }, [emojiPackageURLs])
+
+    // ---- Search ----
+
+    const search = useCallback(
+        (input: string, limit: number = 10): Emoji[] => {
+            if (!input) return []
+            const lower = input.toLowerCase()
+            const results: Emoji[] = []
+            const seen = new Set<string>()
+
+            for (const emoji of allEmojis) {
+                if (results.length >= limit) break
+                const matchShortcode = emoji.shortcode.toLowerCase().includes(lower)
+                const matchKeywords = emoji.keywords?.toLowerCase().includes(lower) ?? false
+                if ((matchShortcode || matchKeywords) && !seen.has(emoji.imageURL)) {
+                    seen.add(emoji.imageURL)
+                    results.push(emoji)
+                }
+            }
+            return results
+        },
+        [allEmojis]
+    )
+
+    const searchResults = useMemo(() => {
+        if (query.length > 0) {
+            return search(query, 64)
+        }
+        return []
+    }, [query, search])
+
+    // ---- Actions ----
+
+    const open = useCallback(
+        (onSelected: (emoji: Emoji) => void) => {
+            onSelectedRef.current = onSelected
+            setActiveTab(frequentEmojis.length > 0 ? 0 : 1)
+            setQuery('')
+            setIsOpen(true)
+        },
+        [frequentEmojis.length]
+    )
+
+    const close = useCallback(() => {
+        setIsOpen(false)
+        setQuery('')
+        onSelectedRef.current = null
+    }, [])
+
+    const selectEmoji = useCallback(
+        (emoji: Emoji) => {
+            // よく使う絵文字を更新
+            const updated = frequentEmojis.filter((e) => e.shortcode !== emoji.shortcode)
+            updated.unshift(emoji)
+            setFrequentEmojis(updated.slice(0, 60))
+
+            onSelectedRef.current?.(emoji)
+        },
+        [frequentEmojis, setFrequentEmojis]
+    )
+
+    // ---- Display data ----
+
+    const title = useMemo(() => {
+        if (query.length > 0) return '検索結果'
+        if (activeTab === 0) return 'よく使う絵文字'
+        return emojiPackages[activeTab - 1]?.name ?? ''
+    }, [query, activeTab, emojiPackages])
+
+    const displayEmojis = useMemo(() => {
+        if (query.length > 0) return searchResults
+        if (activeTab === 0) return frequentEmojis
+        return emojiPackages[activeTab - 1]?.emojis ?? []
+    }, [query, searchResults, activeTab, frequentEmojis, emojiPackages])
+
+    // ---- Rows for content-visibility ----
+
+    const rows = useMemo(() => {
+        const result: Emoji[][] = []
+        for (let i = 0; i < displayEmojis.length; i += COLS) {
+            result.push(displayEmojis.slice(i, i + COLS))
+        }
+        return result
+    }, [displayEmojis])
+
+    // ---- Context value ----
+
+    const value = useMemo(
+        () => ({
+            open,
+            close,
+            search,
+            packages: emojiPackages
+        }),
+        [open, close, search, emojiPackages]
+    )
+
+    return (
+        <EmojiPickerContext.Provider value={value}>
+            {props.children}
+
+            <AnimatePresence>
+                {isOpen && (
+                    <>
+                        {/* Backdrop */}
+                        <motion.div
+                            style={{
+                                position: 'fixed',
+                                inset: 0,
+                                background: 'black',
+                                zIndex: 1000
+                            }}
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 0.5 }}
+                            exit={{ opacity: 0 }}
+                            onClick={close}
+                        />
+
+                        {/* Bottom sheet */}
+                        <motion.div
+                            style={{
+                                position: 'fixed',
+                                bottom: 0,
+                                left: 0,
+                                right: 0,
+                                backgroundColor: CssVar.contentBackground,
+                                color: CssVar.contentText,
+                                borderRadius: `${CssVar.round(1)} ${CssVar.round(1)} 0 0`,
+                                display: 'flex',
+                                flexDirection: 'column',
+                                maxHeight: '50vh',
+                                paddingBottom: 'env(safe-area-inset-bottom)',
+                                zIndex: 1001
+                            }}
+                            initial={{ y: '100%' }}
+                            animate={{ y: 0 }}
+                            exit={{ y: '100%' }}
+                            transition={{ type: 'tween', ease: 'easeOut', duration: 0.2 }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            {/* Handle */}
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    justifyContent: 'center',
+                                    padding: `${CssVar.space(2)} 0 ${CssVar.space(1)}`
+                                }}
+                            >
+                                <div
+                                    style={{
+                                        width: '30px',
+                                        height: '6px',
+                                        borderRadius: CssVar.round(0.5),
+                                        backgroundColor: CssVar.divider
+                                    }}
+                                />
+                            </div>
+
+                            {/* Tabs */}
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    overflowX: 'auto',
+                                    gap: CssVar.space(1),
+                                    padding: `0 ${CssVar.space(2)}`,
+                                    flexShrink: 0
+                                }}
+                            >
+                                {/* よく使うタブ or 検索結果タブ */}
+                                {query.length === 0 ? (
+                                    <TabButton
+                                        selected={activeTab === 0}
+                                        onClick={() => {
+                                            setActiveTab(0)
+                                            gridRef.current?.scrollTo(0, 0)
+                                        }}
+                                    >
+                                        <MdAccessTime size={20} />
+                                    </TabButton>
+                                ) : (
+                                    <TabButton selected>
+                                        <MdSearch size={20} />
+                                    </TabButton>
+                                )}
+
+                                {/* パッケージタブ */}
+                                {emojiPackages.map((pkg, index) => (
+                                    <TabButton
+                                        key={pkg.packageURL}
+                                        selected={query.length === 0 && activeTab === index + 1}
+                                        onClick={() => {
+                                            setQuery('')
+                                            setActiveTab(index + 1)
+                                            gridRef.current?.scrollTo(0, 0)
+                                        }}
+                                    >
+                                        <img
+                                            src={pkg.iconURL}
+                                            alt={pkg.name}
+                                            style={{ width: '20px', height: '20px' }}
+                                        />
+                                    </TabButton>
+                                ))}
+                            </div>
+
+                            {/* Divider */}
+                            <div
+                                style={{
+                                    height: '1px',
+                                    backgroundColor: CssVar.divider,
+                                    margin: `${CssVar.space(1)} 0`
+                                }}
+                            />
+
+                            {/* Search */}
+                            <div
+                                style={{
+                                    padding: `0 ${CssVar.space(2)}`,
+                                    flexShrink: 0
+                                }}
+                            >
+                                <div
+                                    style={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: CssVar.space(1),
+                                        padding: `${CssVar.space(1)} ${CssVar.space(2)}`,
+                                        borderRadius: CssVar.round(0.5),
+                                        backgroundColor: `rgb(from ${CssVar.contentText} r g b / 0.06)`
+                                    }}
+                                >
+                                    <MdSearch size={18} style={{ opacity: 0.5, flexShrink: 0 }} />
+                                    <input
+                                        type="text"
+                                        placeholder="絵文字を検索..."
+                                        value={query}
+                                        onChange={(e) => setQuery(e.target.value)}
+                                        style={{
+                                            flex: 1,
+                                            border: 'none',
+                                            outline: 'none',
+                                            background: 'transparent',
+                                            color: CssVar.contentText,
+                                            fontSize: '14px'
+                                        }}
+                                    />
+                                    {query.length > 0 && (
+                                        <IconButton onClick={() => setQuery('')} style={{ padding: '2px' }}>
+                                            <MdClose size={16} />
+                                        </IconButton>
+                                    )}
+                                </div>
+                            </div>
+
+                            {/* Title */}
+                            <div
+                                style={{
+                                    padding: `${CssVar.space(1)} ${CssVar.space(2)}`,
+                                    fontSize: '12px',
+                                    opacity: 0.6,
+                                    flexShrink: 0
+                                }}
+                            >
+                                {title}
+                            </div>
+
+                            {/* Emoji grid */}
+                            <div
+                                ref={gridRef}
+                                style={{
+                                    flex: 1,
+                                    overflowY: 'auto',
+                                    overflowX: 'hidden',
+                                    padding: `0 ${CssVar.space(2)} ${CssVar.space(2)}`,
+                                    minHeight: 0
+                                }}
+                            >
+                                {rows.length === 0 ? (
+                                    <div
+                                        style={{
+                                            display: 'flex',
+                                            justifyContent: 'center',
+                                            alignItems: 'center',
+                                            height: '100px',
+                                            opacity: 0.4,
+                                            fontSize: '14px'
+                                        }}
+                                    >
+                                        {query.length > 0
+                                            ? '一致する絵文字がありません'
+                                            : activeTab === 0
+                                              ? 'まだ使った絵文字がありません'
+                                              : '絵文字がありません'}
+                                    </div>
+                                ) : (
+                                    rows.map((row, rowIndex) => (
+                                        <div
+                                            key={rowIndex}
+                                            style={
+                                                {
+                                                    display: 'grid',
+                                                    gridTemplateColumns: `repeat(${COLS}, 1fr)`,
+                                                    contentVisibility: 'auto',
+                                                    containIntrinsicHeight: '44px'
+                                                } as React.CSSProperties
+                                            }
+                                        >
+                                            {row.map((emoji) => (
+                                                <button
+                                                    key={emoji.shortcode}
+                                                    onClick={() => selectEmoji(emoji)}
+                                                    style={{
+                                                        display: 'flex',
+                                                        justifyContent: 'center',
+                                                        alignItems: 'center',
+                                                        width: '100%',
+                                                        aspectRatio: '1',
+                                                        border: 'none',
+                                                        background: 'transparent',
+                                                        borderRadius: CssVar.round(0.5),
+                                                        cursor: 'pointer',
+                                                        padding: '4px',
+                                                        WebkitTapHighlightColor: 'transparent'
+                                                    }}
+                                                >
+                                                    <img
+                                                        src={emoji.imageURL}
+                                                        alt={emoji.shortcode}
+                                                        loading="lazy"
+                                                        style={{
+                                                            width: '28px',
+                                                            height: '28px'
+                                                        }}
+                                                    />
+                                                </button>
+                                            ))}
+                                        </div>
+                                    ))
+                                )}
+                            </div>
+                        </motion.div>
+                    </>
+                )}
+            </AnimatePresence>
+        </EmojiPickerContext.Provider>
+    )
+}
+
+// ---- Tab button ----
+
+const TabButton = (props: { selected?: boolean; onClick?: () => void; children: React.ReactNode }) => {
+    return (
+        <button
+            onClick={props.onClick}
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: `${CssVar.space(1)} ${CssVar.space(2)}`,
+                border: 'none',
+                background: props.selected ? `rgb(from ${CssVar.contentText} r g b / 0.1)` : 'transparent',
+                borderRadius: CssVar.round(0.5),
+                cursor: 'pointer',
+                color: CssVar.contentText,
+                opacity: props.selected ? 1 : 0.5,
+                flexShrink: 0,
+                WebkitTapHighlightColor: 'transparent'
+            }}
+        >
+            {props.children}
+        </button>
+    )
+}
+
+// ---- Hook ----
+
+export const useEmojiPicker = (): EmojiPickerState => {
+    const ctx = useContext(EmojiPickerContext)
+    if (!ctx) {
+        throw new Error('useEmojiPicker must be used within an EmojiPickerProvider')
+    }
+    return ctx
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from './contexts/Theme'
 import { PreferenceProvider } from './contexts/Preference'
 import { SelectProvider } from './contexts/Select'
 import { DrawerProvider } from './contexts/Drawer'
+import { EmojiPickerProvider } from './contexts/EmojiPicker'
 import { ComposerProvider } from './contexts/Composer'
 import { MediaViewerProvider } from './contexts/MediaViewer'
 import { AudioPlayerProvider } from './contexts/AudioPlayer'
@@ -60,6 +61,7 @@ const AuthedRoutes = () => (
             <ImageCropperProvider>
                 <DrawerProvider>
                     <SelectProvider>
+                        <EmojiPickerProvider>
                         <ComposerProvider>
                                     <MediaViewerProvider>
                                         <AudioPlayerProvider>
@@ -93,6 +95,7 @@ const AuthedRoutes = () => (
                                         </AudioPlayerProvider>
                                     </MediaViewerProvider>
                         </ComposerProvider>
+                        </EmojiPickerProvider>
                     </SelectProvider>
                 </DrawerProvider>
             </ImageCropperProvider>


### PR DESCRIPTION
resolve #25 

タイムラインと投稿作成画面で絵文字が表示できるようになりました。

## 変更一覧
#### 表示側: `emojiDict={}` → `message.value.emojis ?? {}` (8ファイル)
1. `app/src/components/message/MarkdownMessage.tsx`
2. `app/src/components/message/OnelineMessage.tsx`
3. `app/src/components/message/ReplyMessage.tsx`
4. `app/src/components/message/MediaMessage.tsx`
5. `web/src/components/message/MarkdownMessage.tsx`
6. `web/src/components/message/OnelineMessage.tsx`
7. `web/src/components/message/ReplyMessage.tsx`
8. `web/src/components/message/MediaMessage.tsx`

#### 投稿側 app版 (1ファイル)
9. `app/src/components/Composer.tsx`
- 変更内容
`emojiDict` ステート追加、絵文字選択時に辞書蓄積、3つのcommit callで `emojis: emojiDict` を含める、クローズ時リセット


#### 投稿側 web版 (3ファイル)
10. `web/src/contexts/EmojiPicker.tsx` - **新規作成** (app版と同一内容)
11. `web/src/main.tsx` - `EmojiPickerProvider` をプロバイダーツリーに追加
12. `web/src/components/Composer.tsx` - `emojiDict` ステート、`textareaRef`、`useEmojiPicker`追加、絵文字ピッカーボタン追加、3つのcommit callで `emojis: emojiDict` を含める、クローズ時リセット

構造としてはこういう流れになっています:

- 投稿時: ユーザーが絵文字ピッカーで選択 → `:shortcode:` がテキストに挿入される + `emojiDict[shortcode] = { imageURL }` が蓄積される → commit時に `value.emojis` として辞書がメッセージに含まれる
- 表示時: `CfmRenderer` が `@concrnt/cfm` で本文をパース → `type: 'Emoji'` ノードを検出 → `emojiDict` から画像URLを引いて `<img>` としてレンダリング

<img width="468" height="973" alt="Screenshot 2026-05-08 18 53 13" src="https://github.com/user-attachments/assets/c339c345-61d8-4a11-87f9-b40291482228" />
