### PR TITLE
リアクション機能を追加しました

### DIFF
--- a/app/src/components/message/MarkdownMessage.tsx
+++ b/app/src/components/message/MarkdownMessage.tsx
@@ -9,6 +9,7 @@ import { Avatar, CfmRenderer, CssVar } from '@concrnt/ui'
 
 import { MessageActions } from './MessageActions'
 import { MessageLayout } from './MessageLayout'
+import { MessageReactions } from './MessageReactions'
 import { TimeDiff } from '../TimeDiff'
 import { PostedTimelines } from './PostedTimelines'
 
@@ -44,6 +45,7 @@ export const MarkdownMessage = (props: MessageProps<MarkdownMessageSchema>) => {
             headerRight={<TimeDiff date={message.createdAt} />}
         >
             <CfmRenderer messagebody={message.value.body} emojiDict={{}} />
+            <MessageReactions message={message} />
             <div
                 style={{
                     display: 'flex',

--- a/app/src/components/message/MediaMessage.tsx
+++ b/app/src/components/message/MediaMessage.tsx
@@ -12,6 +12,7 @@ import { useMediaViewer } from '../../contexts/MediaViewer'
 import { useAudioPlayer } from '../../contexts/AudioPlayer'
 import { MessageActions } from './MessageActions'
 import { MessageLayout } from './MessageLayout'
+import { MessageReactions } from './MessageReactions'
 import { TimeDiff } from '../TimeDiff'
 import { PostedTimelines } from './PostedTimelines'
 
@@ -154,6 +155,7 @@ export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
                     ))}
                 </div>
             )}
+            <MessageReactions message={message} />
             <div
                 style={{
                     display: 'flex',

--- a/app/src/components/message/MessageActions.tsx
+++ b/app/src/components/message/MessageActions.tsx
@@ -12,8 +12,10 @@ import { MdStarOutline } from 'react-icons/md'
 import { MdReply } from 'react-icons/md'
 import { MdRepeat } from 'react-icons/md'
 import { MdMoreHoriz } from 'react-icons/md'
+import { MdAddReaction } from 'react-icons/md'
 import { useDrawer } from '../../contexts/Drawer'
 import { useConfirm } from '../../contexts/Confirm'
+import { useEmojiPicker } from '../../contexts/EmojiPicker'
 
 interface Props {
     message: Message<any>
@@ -30,6 +32,7 @@ export const MessageActions = (props: Props) => {
     const { select } = useSelect()
     const drawer = useDrawer()
     const confirm = useConfirm()
+    const emojiPicker = useEmojiPicker()
 
     const replyCount = props.message.associationCounts?.[Schemas.replyAssociation] ?? 0
     const rerouteCount = props.message.associationCounts?.[Schemas.rerouteAssociation] ?? 0
@@ -130,6 +133,24 @@ export const MessageActions = (props: Props) => {
             >
                 {likeState.ownLike ? <MdStar size={20} color="gold" /> : <MdStarOutline size={20} />}
                 <span style={{ marginLeft: '4px' }}>{likeState.count}</span>
+            </Button>
+            {/* リアクションボタン */}
+            <Button
+                variant="text"
+                onClick={(e) => {
+                    e.stopPropagation()
+                    if (!client) return
+                    emojiPicker.open((emoji) => {
+                        hapticLight()
+                        props.message.reaction(client, emoji.shortcode, emoji.imageURL).catch((err) => {
+                            console.error('Failed to add reaction:', err)
+                        })
+                        emojiPicker.close()
+                    })
+                }}
+                style={{ display: 'flex', alignItems: 'center' }}
+            >
+                <MdAddReaction size={20} />
             </Button>
             {/* メニュー */}
             <Button

--- a/app/src/components/message/MessageReactions.tsx
+++ b/app/src/components/message/MessageReactions.tsx
@@ -1,0 +1,112 @@
+import { Association, Message, ReactionAssociationSchema, Schemas } from '@concrnt/worldlib'
+import { useClient } from '../../contexts/Client'
+import { CssVar } from '../../types/Theme'
+import { useEmojiPicker } from '../../contexts/EmojiPicker'
+import { hapticLight } from '../../utils/haptics'
+
+interface Props {
+    message: Message<any>
+}
+
+export const MessageReactions = (props: Props) => {
+    const { client } = useClient()
+    const emojiPicker = useEmojiPicker()
+
+    const reactionCounts = props.message.reactionCounts
+    if (!reactionCounts || Object.keys(reactionCounts).length === 0) {
+        return null
+    }
+
+    // 自分のリアクションを imageUrl → Association のマップにする
+    const ownReactions: Record<string, Association<ReactionAssociationSchema>> = {}
+    for (const assoc of props.message.ownAssociations) {
+        if (assoc.schema === Schemas.reactionAssociation) {
+            const value = assoc.value as ReactionAssociationSchema
+            ownReactions[value.imageUrl] = assoc as Association<ReactionAssociationSchema>
+        }
+    }
+
+    const handleReactionClick = async (imageUrl: string) => {
+        if (!client) return
+        hapticLight()
+
+        if (ownReactions[imageUrl]) {
+            // 自分のリアクションを削除
+            await ownReactions[imageUrl].delete(client).catch((e) => {
+                console.error('Failed to delete reaction:', e)
+            })
+        } else {
+            // 同じ絵文字でリアクションを追加
+            // shortcodeが必要なので、既存のリアクションからvariantで取得するか、
+            // 無い場合はimageUrlから推測する
+            // emojiPickerのpackagesから探す
+            let shortcode = ''
+            for (const pkg of emojiPicker.packages) {
+                const found = pkg.emojis.find((e) => e.imageURL === imageUrl)
+                if (found) {
+                    shortcode = found.shortcode
+                    break
+                }
+            }
+            if (!shortcode) {
+                // URLの末尾からファイル名を推測
+                shortcode =
+                    imageUrl
+                        .split('/')
+                        .pop()
+                        ?.replace(/\.\w+$/, '') ?? 'emoji'
+            }
+
+            await props.message.reaction(client, shortcode, imageUrl).catch((e) => {
+                console.error('Failed to add reaction:', e)
+            })
+        }
+    }
+
+    return (
+        <div
+            style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: '6px'
+            }}
+        >
+            {Object.entries(reactionCounts).map(([imageUrl, count]) => {
+                const isOwn = !!ownReactions[imageUrl]
+                return (
+                    <button
+                        key={imageUrl}
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            handleReactionClick(imageUrl)
+                        }}
+                        style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '4px',
+                            padding: '2px 8px',
+                            borderRadius: '12px',
+                            border: isOwn ? `1.5px solid ${CssVar.contentLink}` : `1px solid ${CssVar.divider}`,
+                            backgroundColor: isOwn ? `rgb(from ${CssVar.contentLink} r g b / 0.15)` : 'transparent',
+                            cursor: 'pointer',
+                            color: CssVar.contentText,
+                            fontSize: '13px',
+                            WebkitTapHighlightColor: 'transparent'
+                        }}
+                    >
+                        <img
+                            src={imageUrl}
+                            alt=""
+                            style={{
+                                height: '18px',
+                                width: '18px',
+                                objectFit: 'contain'
+                            }}
+                        />
+                        <span>{count}</span>
+                    </button>
+                )
+            })}
+        </div>
+    )
+}

--- a/app/src/components/message/ReplyMessage.tsx
+++ b/app/src/components/message/ReplyMessage.tsx
@@ -9,6 +9,7 @@ import { Avatar, CfmRenderer, CssVar } from '@concrnt/ui'
 
 import { MessageActions } from './MessageActions'
 import { MessageLayout } from './MessageLayout'
+import { MessageReactions } from './MessageReactions'
 import { MessageContainer } from './main'
 import { TimeDiff } from '../TimeDiff'
 import { PostedTimelines } from './PostedTimelines'
@@ -51,6 +52,7 @@ export const ReplyMessage = (props: MessageProps<ReplyMessageSchema>) => {
                 headerRight={<TimeDiff date={props.message.createdAt} />}
             >
                 <CfmRenderer messagebody={props.message.value.body} emojiDict={{}} />
+                <MessageReactions message={props.message} />
                 <div
                     style={{
                         display: 'flex',

--- a/web/src/components/message/MarkdownMessage.tsx
+++ b/web/src/components/message/MarkdownMessage.tsx
@@ -5,6 +5,7 @@ import { Avatar, CfmRenderer, CssVar } from '@concrnt/ui'
 
 import { MessageActions } from './MessageActions'
 import { MessageLayout } from './MessageLayout'
+import { MessageReactions } from './MessageReactions'
 import { TimeDiff } from '../TimeDiff'
 import { PostedTimelines } from './PostedTimelines'
 import { useNavigate } from 'react-router-dom'
@@ -41,6 +42,7 @@ export const MarkdownMessage = (props: MessageProps<MarkdownMessageSchema>) => {
             headerRight={<TimeDiff date={message.createdAt} />}
         >
             <CfmRenderer messagebody={message.value.body} emojiDict={{}} />
+            <MessageReactions message={message} />
             <div
                 style={{
                     display: 'flex',

--- a/web/src/components/message/MediaMessage.tsx
+++ b/web/src/components/message/MediaMessage.tsx
@@ -8,6 +8,7 @@ import { useMediaViewer } from '../../contexts/MediaViewer'
 import { useAudioPlayer } from '../../contexts/AudioPlayer'
 import { MessageActions } from './MessageActions'
 import { MessageLayout } from './MessageLayout'
+import { MessageReactions } from './MessageReactions'
 import { TimeDiff } from '../TimeDiff'
 import { PostedTimelines } from './PostedTimelines'
 import { useNavigate } from 'react-router-dom'
@@ -149,6 +150,7 @@ export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
                     ))}
                 </div>
             )}
+            <MessageReactions message={message} />
             <div
                 style={{
                     display: 'flex',

--- a/web/src/components/message/MessageActions.tsx
+++ b/web/src/components/message/MessageActions.tsx
@@ -12,8 +12,10 @@ import { MdStarOutline } from 'react-icons/md'
 import { MdReply } from 'react-icons/md'
 import { MdRepeat } from 'react-icons/md'
 import { MdMoreHoriz } from 'react-icons/md'
+import { MdAddReaction } from 'react-icons/md'
 import { useDrawer } from '../../contexts/Drawer'
 import { useConfirm } from '../../contexts/Confirm'
+import { useEmojiPicker } from '../../contexts/EmojiPicker'
 
 interface Props {
     message: Message<any>
@@ -30,6 +32,7 @@ export const MessageActions = (props: Props) => {
     const { select } = useSelect()
     const drawer = useDrawer()
     const confirm = useConfirm()
+    const emojiPicker = useEmojiPicker()
 
     const replyCount = props.message.associationCounts?.[Schemas.replyAssociation] ?? 0
     const rerouteCount = props.message.associationCounts?.[Schemas.rerouteAssociation] ?? 0
@@ -130,6 +133,24 @@ export const MessageActions = (props: Props) => {
             >
                 {likeState.ownLike ? <MdStar size={20} color="gold" /> : <MdStarOutline size={20} />}
                 <span style={{ marginLeft: '4px' }}>{likeState.count}</span>
+            </Button>
+            {/* リアクションボタン */}
+            <Button
+                variant="text"
+                onClick={(e) => {
+                    e.stopPropagation()
+                    if (!client) return
+                    emojiPicker.open((emoji) => {
+                        hapticLight()
+                        props.message.reaction(client, emoji.shortcode, emoji.imageURL).catch((err) => {
+                            console.error('Failed to add reaction:', err)
+                        })
+                        emojiPicker.close()
+                    })
+                }}
+                style={{ display: 'flex', alignItems: 'center' }}
+            >
+                <MdAddReaction size={20} />
             </Button>
             {/* メニュー */}
             <Button

--- a/web/src/components/message/MessageReactions.tsx
+++ b/web/src/components/message/MessageReactions.tsx
@@ -1,0 +1,108 @@
+import { Association, Message, ReactionAssociationSchema, Schemas } from '@concrnt/worldlib'
+import { useClient } from '../../contexts/Client'
+import { CssVar } from '../../types/Theme'
+import { useEmojiPicker } from '../../contexts/EmojiPicker'
+import { hapticLight } from '../../utils/haptics'
+
+interface Props {
+    message: Message<any>
+}
+
+export const MessageReactions = (props: Props) => {
+    const { client } = useClient()
+    const emojiPicker = useEmojiPicker()
+
+    const reactionCounts = props.message.reactionCounts
+    if (!reactionCounts || Object.keys(reactionCounts).length === 0) {
+        return null
+    }
+
+    // 自分のリアクションを imageUrl → Association のマップにする
+    const ownReactions: Record<string, Association<ReactionAssociationSchema>> = {}
+    for (const assoc of props.message.ownAssociations) {
+        if (assoc.schema === Schemas.reactionAssociation) {
+            const value = assoc.value as ReactionAssociationSchema
+            ownReactions[value.imageUrl] = assoc as Association<ReactionAssociationSchema>
+        }
+    }
+
+    const handleReactionClick = async (imageUrl: string) => {
+        if (!client) return
+        hapticLight()
+
+        if (ownReactions[imageUrl]) {
+            // 自分のリアクションを削除
+            await ownReactions[imageUrl].delete(client).catch((e) => {
+                console.error('Failed to delete reaction:', e)
+            })
+        } else {
+            // 同じ絵文字でリアクションを追加
+            let shortcode = ''
+            for (const pkg of emojiPicker.packages) {
+                const found = pkg.emojis.find((e) => e.imageURL === imageUrl)
+                if (found) {
+                    shortcode = found.shortcode
+                    break
+                }
+            }
+            if (!shortcode) {
+                shortcode = imageUrl.split('/').pop()?.replace(/\.\w+$/, '') ?? 'emoji'
+            }
+
+            await props.message.reaction(client, shortcode, imageUrl).catch((e) => {
+                console.error('Failed to add reaction:', e)
+            })
+        }
+    }
+
+    return (
+        <div
+            style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: '6px'
+            }}
+        >
+            {Object.entries(reactionCounts).map(([imageUrl, count]) => {
+                const isOwn = !!ownReactions[imageUrl]
+                return (
+                    <button
+                        key={imageUrl}
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            handleReactionClick(imageUrl)
+                        }}
+                        style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '4px',
+                            padding: '2px 8px',
+                            borderRadius: '12px',
+                            border: isOwn
+                                ? `1.5px solid ${CssVar.contentLink}`
+                                : `1px solid ${CssVar.divider}`,
+                            backgroundColor: isOwn
+                                ? `rgb(from ${CssVar.contentLink} r g b / 0.15)`
+                                : 'transparent',
+                            cursor: 'pointer',
+                            color: CssVar.contentText,
+                            fontSize: '13px',
+                            WebkitTapHighlightColor: 'transparent'
+                        }}
+                    >
+                        <img
+                            src={imageUrl}
+                            alt=""
+                            style={{
+                                height: '18px',
+                                width: '18px',
+                                objectFit: 'contain'
+                            }}
+                        />
+                        <span>{count}</span>
+                    </button>
+                )
+            })}
+        </div>
+    )
+}

--- a/web/src/components/message/ReplyMessage.tsx
+++ b/web/src/components/message/ReplyMessage.tsx
@@ -5,6 +5,7 @@ import { Avatar, CfmRenderer, CssVar } from '@concrnt/ui'
 
 import { MessageActions } from './MessageActions'
 import { MessageLayout } from './MessageLayout'
+import { MessageReactions } from './MessageReactions'
 import { MessageContainer } from './main'
 import { TimeDiff } from '../TimeDiff'
 import { PostedTimelines } from './PostedTimelines'
@@ -48,6 +49,7 @@ export const ReplyMessage = (props: MessageProps<ReplyMessageSchema>) => {
                 headerRight={<TimeDiff date={props.message.createdAt} />}
             >
                 <CfmRenderer messagebody={props.message.value.body} emojiDict={{}} />
+                <MessageReactions message={props.message} />
                 <div
                     style={{
                         display: 'flex',

--- a/web/src/contexts/EmojiPicker.tsx
+++ b/web/src/contexts/EmojiPicker.tsx
@@ -1,0 +1,479 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { AnimatePresence, motion } from 'motion/react'
+import { CssVar } from '../types/Theme'
+import { useLocalStorage } from '../hooks/useLocalStorage'
+import { MdAccessTime, MdSearch, MdClose } from 'react-icons/md'
+import { IconButton } from '@concrnt/ui'
+
+// ---- Types ----
+
+export interface Emoji {
+    shortcode: string
+    imageURL: string
+    keywords?: string
+}
+
+export interface RawEmojiPackage {
+    name: string
+    iconURL: string
+    emojis: Emoji[]
+}
+
+export interface EmojiPackage extends RawEmojiPackage {
+    packageURL: string
+    fetchedAt: Date
+}
+
+// ---- Constants ----
+
+const TWEMOJI_URL = 'https://gist.githubusercontent.com/totegamma/6e1a047f54960f6bb7b946064664d793/raw/twemoji.json'
+const COLS = 8
+
+// ---- Context ----
+
+export interface EmojiPickerState {
+    open: (onSelected: (emoji: Emoji) => void) => void
+    close: () => void
+    search: (input: string, limit?: number) => Emoji[]
+    packages: EmojiPackage[]
+}
+
+const EmojiPickerContext = createContext<EmojiPickerState | undefined>(undefined)
+
+interface Props {
+    children: React.ReactNode
+}
+
+export const EmojiPickerProvider = (props: Props) => {
+    const onSelectedRef = useRef<((emoji: Emoji) => void) | null>(null)
+    const [isOpen, setIsOpen] = useState(false)
+
+    const [frequentEmojis, setFrequentEmojis] = useLocalStorage<Emoji[]>('emojiPicker:frequent', [])
+    const [query, setQuery] = useState('')
+    const [activeTab, setActiveTab] = useState(0)
+
+    const [emojiPackages, setEmojiPackages] = useState<EmojiPackage[]>(() => {
+        const pkgs: EmojiPackage[] = []
+        for (const url of [TWEMOJI_URL]) {
+            const cacheKey = `emojiPackage:${url}`
+            const cache = localStorage.getItem(cacheKey)
+            if (cache) {
+                try {
+                    pkgs.push(JSON.parse(cache))
+                } catch {
+                    localStorage.removeItem(cacheKey)
+                }
+            }
+        }
+        return pkgs
+    })
+    const [allEmojis, setAllEmojis] = useState<Emoji[]>(() => emojiPackages.flatMap((pkg) => pkg.emojis))
+
+    const gridRef = useRef<HTMLDivElement>(null)
+    const searchInputRef = useRef<HTMLInputElement>(null)
+
+    const emojiPackageURLs = useMemo(() => [TWEMOJI_URL], [])
+
+    useEffect(() => {
+        let unmounted = false
+
+        emojiPackageURLs.forEach((url) => {
+            const cacheKey = `emojiPackage:${url}`
+            if (localStorage.getItem(cacheKey)) return
+
+            fetch(url, { signal: AbortSignal.timeout(5000) })
+                .then((res) => res.json())
+                .then((raw: RawEmojiPackage) => {
+                    const pkg: EmojiPackage = {
+                        ...raw,
+                        packageURL: url,
+                        fetchedAt: new Date()
+                    }
+                    if (!unmounted) {
+                        setEmojiPackages((prev) => [...prev, pkg])
+                        setAllEmojis((prev) => [...prev, ...pkg.emojis])
+                        localStorage.setItem(cacheKey, JSON.stringify(pkg))
+                    }
+                })
+                .catch((e) => {
+                    console.error('Failed to fetch emoji package:', url, e)
+                })
+        })
+
+        return () => {
+            unmounted = true
+        }
+    }, [emojiPackageURLs])
+
+    // ---- Search ----
+
+    const search = useCallback(
+        (input: string, limit: number = 10): Emoji[] => {
+            if (!input) return []
+            const lower = input.toLowerCase()
+            const results: Emoji[] = []
+            const seen = new Set<string>()
+
+            for (const emoji of allEmojis) {
+                if (results.length >= limit) break
+                const matchShortcode = emoji.shortcode.toLowerCase().includes(lower)
+                const matchKeywords = emoji.keywords?.toLowerCase().includes(lower) ?? false
+                if ((matchShortcode || matchKeywords) && !seen.has(emoji.imageURL)) {
+                    seen.add(emoji.imageURL)
+                    results.push(emoji)
+                }
+            }
+            return results
+        },
+        [allEmojis]
+    )
+
+    const searchResults = useMemo(() => {
+        if (query.length > 0) {
+            return search(query, 64)
+        }
+        return []
+    }, [query, search])
+
+    // ---- Actions ----
+
+    const open = useCallback(
+        (onSelected: (emoji: Emoji) => void) => {
+            onSelectedRef.current = onSelected
+            setActiveTab(frequentEmojis.length > 0 ? 0 : 1)
+            setQuery('')
+            setIsOpen(true)
+            // auto focus search on next tick
+            setTimeout(() => searchInputRef.current?.focus(), 100)
+        },
+        [frequentEmojis.length]
+    )
+
+    const close = useCallback(() => {
+        setIsOpen(false)
+        setQuery('')
+        onSelectedRef.current = null
+    }, [])
+
+    const selectEmoji = useCallback(
+        (emoji: Emoji) => {
+            const updated = frequentEmojis.filter((e) => e.shortcode !== emoji.shortcode)
+            updated.unshift(emoji)
+            setFrequentEmojis(updated.slice(0, 60))
+
+            onSelectedRef.current?.(emoji)
+        },
+        [frequentEmojis, setFrequentEmojis]
+    )
+
+    // ---- Display data ----
+
+    const title = useMemo(() => {
+        if (query.length > 0) return '検索結果'
+        if (activeTab === 0) return 'よく使う絵文字'
+        return emojiPackages[activeTab - 1]?.name ?? ''
+    }, [query, activeTab, emojiPackages])
+
+    const displayEmojis = useMemo(() => {
+        if (query.length > 0) return searchResults
+        if (activeTab === 0) return frequentEmojis
+        return emojiPackages[activeTab - 1]?.emojis ?? []
+    }, [query, searchResults, activeTab, frequentEmojis, emojiPackages])
+
+    const rows = useMemo(() => {
+        const result: Emoji[][] = []
+        for (let i = 0; i < displayEmojis.length; i += COLS) {
+            result.push(displayEmojis.slice(i, i + COLS))
+        }
+        return result
+    }, [displayEmojis])
+
+    // ---- Context value ----
+
+    const value = useMemo(
+        () => ({
+            open,
+            close,
+            search,
+            packages: emojiPackages
+        }),
+        [open, close, search, emojiPackages]
+    )
+
+    return (
+        <EmojiPickerContext.Provider value={value}>
+            {props.children}
+
+            <AnimatePresence>
+                {isOpen && (
+                    <>
+                        {/* Backdrop */}
+                        <motion.div
+                            style={{
+                                position: 'fixed',
+                                inset: 0,
+                                background: 'black',
+                                zIndex: 1000
+                            }}
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 0.5 }}
+                            exit={{ opacity: 0 }}
+                            onClick={close}
+                        />
+
+                        {/* Centered dialog */}
+                        <motion.div
+                            style={{
+                                position: 'fixed',
+                                top: '50%',
+                                left: '50%',
+                                transform: 'translate(-50%, -50%)',
+                                backgroundColor: CssVar.contentBackground,
+                                color: CssVar.contentText,
+                                borderRadius: CssVar.round(2),
+                                display: 'flex',
+                                flexDirection: 'column',
+                                width: '380px',
+                                maxWidth: '90vw',
+                                maxHeight: '480px',
+                                zIndex: 1001,
+                                overflow: 'hidden'
+                            }}
+                            initial={{ opacity: 0, scale: 0.95 }}
+                            animate={{ opacity: 1, scale: 1 }}
+                            exit={{ opacity: 0, scale: 0.95 }}
+                            transition={{ type: 'tween', ease: 'easeOut', duration: 0.15 }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            {/* Tabs */}
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    overflowX: 'auto',
+                                    gap: CssVar.space(1),
+                                    padding: `${CssVar.space(2)} ${CssVar.space(2)} 0`,
+                                    flexShrink: 0
+                                }}
+                            >
+                                {query.length === 0 ? (
+                                    <TabButton
+                                        selected={activeTab === 0}
+                                        onClick={() => {
+                                            setActiveTab(0)
+                                            gridRef.current?.scrollTo(0, 0)
+                                        }}
+                                    >
+                                        <MdAccessTime size={20} />
+                                    </TabButton>
+                                ) : (
+                                    <TabButton selected>
+                                        <MdSearch size={20} />
+                                    </TabButton>
+                                )}
+
+                                {emojiPackages.map((pkg, index) => (
+                                    <TabButton
+                                        key={pkg.packageURL}
+                                        selected={query.length === 0 && activeTab === index + 1}
+                                        onClick={() => {
+                                            setQuery('')
+                                            setActiveTab(index + 1)
+                                            gridRef.current?.scrollTo(0, 0)
+                                        }}
+                                    >
+                                        <img
+                                            src={pkg.iconURL}
+                                            alt={pkg.name}
+                                            style={{ width: '20px', height: '20px' }}
+                                        />
+                                    </TabButton>
+                                ))}
+                            </div>
+
+                            {/* Divider */}
+                            <div
+                                style={{
+                                    height: '1px',
+                                    backgroundColor: CssVar.divider,
+                                    margin: `${CssVar.space(1)} 0`
+                                }}
+                            />
+
+                            {/* Search */}
+                            <div
+                                style={{
+                                    padding: `0 ${CssVar.space(2)}`,
+                                    flexShrink: 0
+                                }}
+                            >
+                                <div
+                                    style={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: CssVar.space(1),
+                                        padding: `${CssVar.space(1)} ${CssVar.space(2)}`,
+                                        borderRadius: CssVar.round(0.5),
+                                        backgroundColor: `rgb(from ${CssVar.contentText} r g b / 0.06)`
+                                    }}
+                                >
+                                    <MdSearch size={18} style={{ opacity: 0.5, flexShrink: 0 }} />
+                                    <input
+                                        ref={searchInputRef}
+                                        type="text"
+                                        placeholder="絵文字を検索..."
+                                        value={query}
+                                        onChange={(e) => setQuery(e.target.value)}
+                                        style={{
+                                            flex: 1,
+                                            border: 'none',
+                                            outline: 'none',
+                                            background: 'transparent',
+                                            color: CssVar.contentText,
+                                            fontSize: '14px'
+                                        }}
+                                    />
+                                    {query.length > 0 && (
+                                        <IconButton onClick={() => setQuery('')} style={{ padding: '2px' }}>
+                                            <MdClose size={16} />
+                                        </IconButton>
+                                    )}
+                                </div>
+                            </div>
+
+                            {/* Title */}
+                            <div
+                                style={{
+                                    padding: `${CssVar.space(1)} ${CssVar.space(2)}`,
+                                    fontSize: '12px',
+                                    opacity: 0.6,
+                                    flexShrink: 0
+                                }}
+                            >
+                                {title}
+                            </div>
+
+                            {/* Emoji grid */}
+                            <div
+                                ref={gridRef}
+                                style={{
+                                    flex: 1,
+                                    overflowY: 'auto',
+                                    overflowX: 'hidden',
+                                    padding: `0 ${CssVar.space(2)} ${CssVar.space(2)}`,
+                                    minHeight: 0
+                                }}
+                            >
+                                {rows.length === 0 ? (
+                                    <div
+                                        style={{
+                                            display: 'flex',
+                                            justifyContent: 'center',
+                                            alignItems: 'center',
+                                            height: '100px',
+                                            opacity: 0.4,
+                                            fontSize: '14px'
+                                        }}
+                                    >
+                                        {query.length > 0
+                                            ? '一致する絵文字がありません'
+                                            : activeTab === 0
+                                              ? 'まだ使った絵文字がありません'
+                                              : '絵文字がありません'}
+                                    </div>
+                                ) : (
+                                    rows.map((row, rowIndex) => (
+                                        <div
+                                            key={rowIndex}
+                                            style={
+                                                {
+                                                    display: 'grid',
+                                                    gridTemplateColumns: `repeat(${COLS}, 1fr)`,
+                                                    contentVisibility: 'auto',
+                                                    containIntrinsicHeight: '44px'
+                                                } as React.CSSProperties
+                                            }
+                                        >
+                                            {row.map((emoji) => (
+                                                <button
+                                                    key={emoji.shortcode}
+                                                    onClick={() => selectEmoji(emoji)}
+                                                    style={{
+                                                        display: 'flex',
+                                                        justifyContent: 'center',
+                                                        alignItems: 'center',
+                                                        width: '100%',
+                                                        aspectRatio: '1',
+                                                        border: 'none',
+                                                        background: 'transparent',
+                                                        borderRadius: CssVar.round(0.5),
+                                                        cursor: 'pointer',
+                                                        padding: '4px',
+                                                        WebkitTapHighlightColor: 'transparent'
+                                                    }}
+                                                    onMouseOver={(e) => {
+                                                        ;(e.currentTarget as HTMLElement).style.backgroundColor =
+                                                            `rgb(from ${CssVar.contentText} r g b / 0.1)`
+                                                    }}
+                                                    onMouseOut={(e) => {
+                                                        ;(e.currentTarget as HTMLElement).style.backgroundColor =
+                                                            'transparent'
+                                                    }}
+                                                >
+                                                    <img
+                                                        src={emoji.imageURL}
+                                                        alt={emoji.shortcode}
+                                                        loading="lazy"
+                                                        style={{
+                                                            width: '28px',
+                                                            height: '28px'
+                                                        }}
+                                                    />
+                                                </button>
+                                            ))}
+                                        </div>
+                                    ))
+                                )}
+                            </div>
+                        </motion.div>
+                    </>
+                )}
+            </AnimatePresence>
+        </EmojiPickerContext.Provider>
+    )
+}
+
+// ---- Tab button ----
+
+const TabButton = (props: { selected?: boolean; onClick?: () => void; children: React.ReactNode }) => {
+    return (
+        <button
+            onClick={props.onClick}
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: `${CssVar.space(1)} ${CssVar.space(2)}`,
+                border: 'none',
+                background: props.selected ? `rgb(from ${CssVar.contentText} r g b / 0.1)` : 'transparent',
+                borderRadius: CssVar.round(0.5),
+                cursor: 'pointer',
+                color: CssVar.contentText,
+                opacity: props.selected ? 1 : 0.5,
+                flexShrink: 0,
+                WebkitTapHighlightColor: 'transparent'
+            }}
+        >
+            {props.children}
+        </button>
+    )
+}
+
+// ---- Hook ----
+
+export const useEmojiPicker = (): EmojiPickerState => {
+    const ctx = useContext(EmojiPickerContext)
+    if (!ctx) {
+        throw new Error('useEmojiPicker must be used within an EmojiPickerProvider')
+    }
+    return ctx
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -16,6 +16,7 @@ import { AudioPlayerProvider } from './contexts/AudioPlayer'
 import { ImageCropperProvider } from './contexts/ImageCropper'
 import TickerProvider from './contexts/Ticer'
 import { ConfirmProvider } from './contexts/Confirm'
+import { EmojiPickerProvider } from './contexts/EmojiPicker'
 import { WelcomeView } from './views/Welcome'
 import { AppShell } from './pages/App'
 import { HomeView } from './views/Home'
@@ -61,6 +62,7 @@ const AuthedRoutes = () => (
                 <DrawerProvider>
                     <SelectProvider>
                         <ComposerProvider>
+                            <EmojiPickerProvider>
                                     <MediaViewerProvider>
                                         <AudioPlayerProvider>
                                         <TickerProvider>
@@ -92,6 +94,7 @@ const AuthedRoutes = () => (
                                         </TickerProvider>
                                         </AudioPlayerProvider>
                                     </MediaViewerProvider>
+                            </EmojiPickerProvider>
                         </ComposerProvider>
                     </SelectProvider>
                 </DrawerProvider>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -17,7 +17,6 @@ import { AudioPlayerProvider } from './contexts/AudioPlayer'
 import { ImageCropperProvider } from './contexts/ImageCropper'
 import TickerProvider from './contexts/Ticer'
 import { ConfirmProvider } from './contexts/Confirm'
-import { EmojiPickerProvider } from './contexts/EmojiPicker'
 import { WelcomeView } from './views/Welcome'
 import { AppShell } from './pages/App'
 import { HomeView } from './views/Home'
@@ -64,7 +63,6 @@ const AuthedRoutes = () => (
                     <SelectProvider>
                         <EmojiPickerProvider>
                         <ComposerProvider>
-                            <EmojiPickerProvider>
                                     <MediaViewerProvider>
                                         <AudioPlayerProvider>
                                         <TickerProvider>
@@ -96,7 +94,6 @@ const AuthedRoutes = () => (
                                         </TickerProvider>
                                         </AudioPlayerProvider>
                                     </MediaViewerProvider>
-                            </EmojiPickerProvider>
                         </ComposerProvider>
                         </EmojiPickerProvider>
                     </SelectProvider>

--- a/worldlib/src/message.ts
+++ b/worldlib/src/message.ts
@@ -1,6 +1,6 @@
 import { Document, SignedDocument } from '@concrnt/client'
 import { Schemas } from './schemas'
-import { LikeAssociationSchema, ProfileSchema } from './schemas/'
+import { LikeAssociationSchema, ProfileSchema, ReactionAssociationSchema } from './schemas/'
 import { User } from './user'
 import { Client } from './client'
 import { Association } from './association'
@@ -103,6 +103,30 @@ export class Message<T> implements Document<T> {
             schema: Schemas.likeAssociation,
             associate: this.uri,
             value: {},
+            distributes,
+            createdAt: new Date()
+        }
+
+        return client.api.commit(document, authorDomain)
+    }
+
+    async reaction(client: Client, shortcode: string, imageUrl: string): Promise<SignedDocument> {
+        const authorDomain = await client.api.getEntity(this.author, this.hint).then((user) => user?.value.domain)
+
+        const distributes = [
+            semantics.activityTimeline(client.ccid, client.currentProfile),
+            semantics.notificationTimeline(this.author, this.authorProfileName || 'main')
+        ]
+
+        const document: Document<ReactionAssociationSchema> = {
+            author: client.ccid,
+            schema: Schemas.reactionAssociation,
+            associate: this.uri,
+            associationVariant: imageUrl,
+            value: {
+                shortcode,
+                imageUrl
+            },
             distributes,
             createdAt: new Date()
         }


### PR DESCRIPTION
resolve #26 

- **`worldlib/src/message.ts`** — `Message` クラスに `reaction(client, shortcode, imageUrl)` メソッドを追加
  - `favorite()` と同じパターンで `client.api.commit()` を使用
  - `associationVariant` に `imageUrl` を指定し、同一絵文字のリアクションを集約
  - `distributes` に通知タイムラインとアクティビティタイムラインを設定

### app（モバイル）

#### 新規ファイル
- **`app/src/components/message/MessageReactions.tsx`** — リアクションチップ表示コンポーネント
  - `message.reactionCounts` から絵文字ごとのチップを表示
  - `ownAssociations` から自分のリアクション済みチップをハイライト
  - チップタップでトグル（追加/削除）

#### 変更ファイル
- **`app/src/components/message/MessageActions.tsx`** — リアクションボタンを追加
  - いいねボタンとメニューボタンの間に `MdAddReaction` アイコンのボタンを配置
  - タップで `EmojiPicker` を開き、選択された絵文字で `message.reaction()` を呼び出し
- **`app/src/components/message/MarkdownMessage.tsx`** — `MessageReactions` を組み込み
- **`app/src/components/message/MediaMessage.tsx`** — 同上
- **`app/src/components/message/ReplyMessage.tsx`** — 同上

### web（デスクトップ）

#### 新規ファイル
- **`web/src/contexts/EmojiPicker.tsx`** — web用の絵文字ピッカー
  - app版のボトムシートに対してデスクトップ向けに中央モーダルダイアログ形式で実装
  - 検索、よく使う絵文字、パッケージタブを搭載
- **`web/src/components/message/MessageReactions.tsx`** — app版と同等のリアクションチップ表示コンポーネント

#### 変更ファイル
- **`web/src/main.tsx`** — `EmojiPickerProvider` をProviderツリーに追加
- **`web/src/components/message/MessageActions.tsx`** — リアクションボタンを追加（app版と同一パターン）
- **`web/src/components/message/MarkdownMessage.tsx`** — `MessageReactions` を組み込み
- **`web/src/components/message/MediaMessage.tsx`** — 同上
- **`web/src/components/message/ReplyMessage.tsx`** — 同上

## 実装の詳細

- リファレンス実装（concrnt-world-ref）の `MessageReactions` / `Message.reaction()` / `EmojiPickerContext` を踏襲
- リアクション作成は `Document` に `associate`（対象メッセージURI）と `associationVariant`（絵文字imageUrl）を設定して `api.commit()` で送信
- リアクション削除は `Association.delete()` を使用
- リアクションチップのタップで同じ絵文字のリアクションをトグル可能。shortcode の逆引きは `emojiPicker.packages` から検索
- app版は既存の `EmojiPickerProvider`（`app/src/contexts/EmojiPicker.tsx`）を使用
- web版は新規に `EmojiPickerProvider` を作成（中央モーダル形式）
