### PR TITLE
縦スクロール時に誤爆しがちだったメニューバーが出る判定を調整しました。

### DIFF
--- a/app/src/layouts/Sidebar.tsx
+++ b/app/src/layouts/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo } from 'react'
+import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useRef } from 'react'
 import { motion, useMotionValue, animate, useTransform } from 'motion/react'
 
 import { MdMenu } from 'react-icons/md'
@@ -6,6 +6,10 @@ import { NavigationProvider } from '../contexts/Navigation'
 import { CssVar } from '../types/Theme'
 
 const SIDEBAR_W = 220
+
+// この値(px)以上縦に指が動いたら「縦スクロール」と判定してサイドバーのドラッグを抑制する。
+// 小さくするとスクロール判定がシビアになり、大きくすると横スワイプ時の縦ブレを許容する。8〜16あたりがよさげです。
+const SCROLL_THRESHOLD = 12
 
 interface Props {
     opened: boolean
@@ -34,6 +38,42 @@ export const SidebarLayout = (props: Props) => {
         return () => controls.stop()
     }, [props.opened, width, x])
 
+    // 縦スクロール検知: タッチの縦移動量が閾値を超えたらスクロールとみなす
+    const pointerStartY = useRef<number | null>(null)
+    const isScrolling = useRef(false)
+
+    useEffect(() => {
+        const handlePointerDown = (e: PointerEvent) => {
+            pointerStartY.current = e.clientY
+            isScrolling.current = false
+        }
+        const handlePointerMove = (e: PointerEvent) => {
+            if (pointerStartY.current === null) return
+            const dy = Math.abs(e.clientY - pointerStartY.current)
+            if (dy > SCROLL_THRESHOLD) {
+                isScrolling.current = true
+            }
+        }
+        const handlePointerUp = () => {
+            pointerStartY.current = null
+            requestAnimationFrame(() => {
+                isScrolling.current = false
+            })
+        }
+
+        window.addEventListener('pointerdown', handlePointerDown)
+        window.addEventListener('pointermove', handlePointerMove)
+        window.addEventListener('pointerup', handlePointerUp)
+        window.addEventListener('pointercancel', handlePointerUp)
+
+        return () => {
+            window.removeEventListener('pointerdown', handlePointerDown)
+            window.removeEventListener('pointermove', handlePointerMove)
+            window.removeEventListener('pointerup', handlePointerUp)
+            window.removeEventListener('pointercancel', handlePointerUp)
+        }
+    }, [])
+
     const popDistance = Math.max(80, width * 0.3) // 画面幅の30% or 80px
     const popVelocity = 100 // px/s 目安
 
@@ -59,7 +99,21 @@ export const SidebarLayout = (props: Props) => {
                 dragElastic={0}
                 dragMomentum={false}
                 dragConstraints={{ left: 0, right: width }}
+                onDrag={() => {
+                    // 縦スクロール中は横ドラッグを無効化（サイドバーを元の位置に固定）
+                    // サイドバーが開いている時は閉じる操作を妨げない
+                    if (!props.opened && isScrolling.current) {
+                        x.set(0)
+                    }
+                }}
                 onDragEnd={(_, info) => {
+                    // 縦スクロール中にドラッグが終了した場合は開閉判定をスキップ
+                    // サイドバーが開いている時は閉じる操作を妨げない
+                    if (!props.opened && isScrolling.current) {
+                        animate(x, 0, { duration: 0.12 })
+                        return
+                    }
+
                     const current = x.get()
 
                     const v = info.velocity.x


### PR DESCRIPTION
resolve #54 
 
## 概要
 
Android端末でタイムラインを縦スクロールした際、指の微妙な横ブレによってサイドバーが誤って開いてしまう問題を修正しました。
 
## 変更内容
 
**変更ファイル:** `app/src/layouts/Sidebar.tsx`
 
タッチの縦方向移動量を監視し、閾値（`SCROLL_THRESHOLD = 12px`）を超えた場合は「縦スクロール中」と判定してサイドバーのドラッグを抑制するようにしました。
 
- `pointerdown` でタッチ開始位置を記録
- `pointermove` で縦方向の移動量が閾値を超えたらスクロール中フラグをON
- `onDrag` でフラグがONの間はサイドバーの位置を固定（`x.set(0)`）
- `onDragEnd` でフラグがONの場合は開閉判定をスキップ
- サイドバーが**開いている時**はスクロール判定をバイパスし、閉じる操作を妨げない
## 補足
 
- `SCROLL_THRESHOLD` の値を変更することでスクロール判定の感度を調整できます
- 既存の `dragDirectionLock` はセーフティネットとして残しています
 