### PR TITLE
URL のプレビュー機能を実装しました

### DIFF
--- a/app/src/components/AutoSummary.tsx
+++ b/app/src/components/AutoSummary.tsx
@@ -1,0 +1,180 @@
+import { ReactNode, useMemo } from 'react'
+import { UrlSummaryCard } from '../components/UrlSummaryCard'
+
+interface Props {
+    body: string
+    limit?: number
+    children: ReactNode
+}
+
+function extractUrls(text: string): string[] {
+    // strip markdown image syntax
+    let replaced = text.replace(/!\[.*?\]\(.*?\)/g, '')
+
+    // strip codeblock
+    replaced = replaced.replace(/```[\s\S]*?```/g, '')
+
+    // strip inline code
+    replaced = replaced.replace(/`[\s\S]*?`/g, '')
+
+    // strip img tag
+    replaced = replaced.replace(/<img.*?>/g, '')
+
+    // strip social tag
+    replaced = replaced.replace(/<social.*?>.*?<\/social>/g, '')
+
+    // strip emojipack tag
+    replaced = replaced.replace(/<emojipack.*?\/>/g, '')
+
+    // replace markdown link syntax to just URL
+    replaced = replaced.replace(/\[.*?\]\((.*?)\)/g, '$1')
+
+    // strip a tag body
+    replaced = replaced.replace(/<a(.*?)>.*?<\/a>/g, '$1')
+
+    // extract urls
+    const urls = replaced.match(/(https?:\/\/[\w.\-?=/&%#,@+:!~]+)/g) ?? []
+
+    // deduplicate
+    return [...new Set(urls)]
+}
+
+export const AutoSummary = (props: Props) => {
+    const limit = props.limit ?? 1
+
+    const urls = useMemo(() => {
+        if (limit <= 0) return []
+        return extractUrls(props.body)
+    }, [props.body, limit])
+
+    return (
+        <>
+            {props.children}
+            {urls.slice(0, limit).map((url, i) => {
+                // YouTube embed
+                let matchYoutube = url.match(/https:\/\/www\.youtube\.com\/watch\?v=([a-zA-Z0-9_-]+)/)
+                if (!matchYoutube) matchYoutube = url.match(/https:\/\/youtu\.be\/([a-zA-Z0-9_-]+)/)
+                if (matchYoutube) {
+                    return (
+                        <div
+                            key={i}
+                            style={{
+                                aspectRatio: '16 / 9',
+                                overflow: 'hidden',
+                                width: '100%',
+                                borderRadius: '8px',
+                                marginTop: '4px'
+                            }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <iframe
+                                allowFullScreen
+                                src={`https://www.youtube.com/embed/${matchYoutube[1]}`}
+                                title="YouTube video player"
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                style={{
+                                    width: '100%',
+                                    height: '100%',
+                                    border: 'none'
+                                }}
+                            />
+                        </div>
+                    )
+                }
+
+                // Spotify embed
+                const matchSpotify = url.match(
+                    /https:\/\/open\.spotify\.com\/([-a-zA-Z0-9]+\/)?(track|album|playlist)\/([a-zA-Z0-9]+)/
+                )
+                if (matchSpotify) {
+                    const type = matchSpotify[2]
+                    const id = matchSpotify[3]
+                    return (
+                        <div
+                            key={i}
+                            style={{
+                                overflow: 'hidden',
+                                width: '100%',
+                                height: '152px',
+                                borderRadius: '8px',
+                                marginTop: '4px'
+                            }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <iframe
+                                allowFullScreen
+                                src={`https://open.spotify.com/embed/${type}/${id}`}
+                                style={{
+                                    width: '100%',
+                                    height: '100%',
+                                    border: 'none'
+                                }}
+                                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                            />
+                        </div>
+                    )
+                }
+
+                // Apple Music embed
+                const matchAppleMusic = url.match(/https:\/\/music\.apple\.com\/([^\s]+)/)
+                if (matchAppleMusic) {
+                    return (
+                        <div
+                            key={i}
+                            style={{
+                                overflow: 'hidden',
+                                width: '100%',
+                                height: '152px',
+                                borderRadius: '8px',
+                                marginTop: '4px'
+                            }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <iframe
+                                allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"
+                                sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation"
+                                src={`https://embed.music.apple.com/${matchAppleMusic[1]}`}
+                                style={{
+                                    width: '100%',
+                                    height: '100%',
+                                    border: 'none'
+                                }}
+                            />
+                        </div>
+                    )
+                }
+
+                // SoundCloud embed
+                const matchSoundcloud = url.match(/https:\/\/soundcloud\.com\/([^\s]+)/)
+                if (matchSoundcloud) {
+                    return (
+                        <div
+                            key={i}
+                            style={{
+                                overflow: 'hidden',
+                                width: '100%',
+                                height: '152px',
+                                borderRadius: '8px',
+                                marginTop: '4px'
+                            }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <iframe
+                                allowFullScreen
+                                src={`https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/${matchSoundcloud[1]}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true`}
+                                style={{
+                                    width: '100%',
+                                    height: '100%',
+                                    border: 'none'
+                                }}
+                            />
+                        </div>
+                    )
+                }
+
+                // Default: URL summary card
+                return <UrlSummaryCard key={i} url={url} />
+            })}
+        </>
+    )
+}

--- a/app/src/components/UrlSummaryCard.tsx
+++ b/app/src/components/UrlSummaryCard.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useState } from 'react'
+import { type Summary, useUrlSummary } from '../contexts/UrlSummary'
+import { CssVar } from '../types/Theme'
+
+interface Props {
+    url: string
+}
+
+export const UrlSummaryCard = (props: Props) => {
+    const service = useUrlSummary()
+    const [preview, setPreview] = useState<Summary | undefined>(undefined)
+    const [errored, setErrored] = useState(false)
+
+    useEffect(() => {
+        if (!service) return
+        service
+            .getSummary(props.url)
+            .then((summary) => {
+                if (summary) setPreview(summary)
+                else setErrored(true)
+            })
+            .catch(() => {
+                setErrored(true)
+            })
+    }, [props.url, service])
+
+    if (!service || errored) return null
+
+    let hostname = ''
+    try {
+        hostname = new URL(props.url).hostname
+    } catch {
+        hostname = props.url
+    }
+
+    if (!preview) {
+        return (
+            <div
+                style={{
+                    display: 'flex',
+                    height: '80px',
+                    width: '100%',
+                    overflow: 'hidden',
+                    borderRadius: CssVar.round(1),
+                    border: `1px solid ${CssVar.divider}`
+                }}
+            >
+                <div
+                    style={{
+                        width: '80px',
+                        height: '80px',
+                        flexShrink: 0,
+                        backgroundColor: CssVar.divider
+                    }}
+                />
+                <div
+                    style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '4px',
+                        padding: '8px',
+                        flex: 1,
+                        overflow: 'hidden'
+                    }}
+                >
+                    <div
+                        style={{
+                            height: '14px',
+                            width: '60%',
+                            backgroundColor: CssVar.divider,
+                            borderRadius: '4px'
+                        }}
+                    />
+                    <div
+                        style={{
+                            height: '12px',
+                            width: '90%',
+                            backgroundColor: CssVar.divider,
+                            borderRadius: '4px'
+                        }}
+                    />
+                    <div
+                        style={{
+                            height: '12px',
+                            width: '40%',
+                            backgroundColor: CssVar.divider,
+                            borderRadius: '4px'
+                        }}
+                    />
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <a
+            href={props.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => {
+                e.stopPropagation()
+            }}
+            style={{
+                display: 'flex',
+                height: '80px',
+                width: '100%',
+                overflow: 'hidden',
+                textDecoration: 'none',
+                color: 'inherit',
+                borderRadius: CssVar.round(1),
+                border: `1px solid ${CssVar.divider}`
+            }}
+        >
+            {(preview.thumbnail || preview.icon) && (
+                <div
+                    style={{
+                        width: '80px',
+                        height: '80px',
+                        backgroundSize: 'cover',
+                        backgroundPosition: 'center',
+                        backgroundImage: `url(${preview.thumbnail || preview.icon})`,
+                        flexShrink: 0
+                    }}
+                />
+            )}
+            <div
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    padding: '8px',
+                    height: '80px',
+                    overflow: 'hidden',
+                    flex: 1,
+                    gap: '2px',
+                    boxSizing: 'border-box'
+                }}
+            >
+                <div
+                    style={{
+                        fontWeight: 'bold',
+                        fontSize: '13px',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        lineHeight: 1.3
+                    }}
+                >
+                    {preview.title || hostname}
+                </div>
+                <div
+                    style={{
+                        fontSize: '12px',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        flex: 1,
+                        lineHeight: 1.3,
+                        opacity: 0.7,
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical'
+                    }}
+                >
+                    {preview.description || ''}
+                </div>
+                <div
+                    style={{
+                        fontSize: '11px',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        opacity: 0.5
+                    }}
+                >
+                    {hostname}
+                </div>
+            </div>
+        </a>
+    )
+}

--- a/app/src/components/message/MarkdownMessage.tsx
+++ b/app/src/components/message/MarkdownMessage.tsx
@@ -10,6 +10,7 @@ import { Avatar, CfmRenderer } from '@concrnt/ui'
 import { MessageLayout } from './MessageLayout'
 import { TimeDiff } from '../TimeDiff'
 import { MessageFooter } from './Footer'
+import { AutoSummary } from '../AutoSummary'
 
 export const MarkdownMessage = (props: MessageProps<MarkdownMessageSchema>) => {
     const { push } = useStack()
@@ -42,7 +43,9 @@ export const MarkdownMessage = (props: MessageProps<MarkdownMessageSchema>) => {
             }
             headerRight={<TimeDiff date={message.createdAt} />}
         >
-            <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
+            <AutoSummary body={message.value.body ?? ''}>
+                <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
+            </AutoSummary>
             <MessageFooter message={message} />
         </MessageLayout>
     )

--- a/app/src/components/message/MediaMessage.tsx
+++ b/app/src/components/message/MediaMessage.tsx
@@ -13,6 +13,7 @@ import { useAudioPlayer } from '../../contexts/AudioPlayer'
 import { MessageLayout } from './MessageLayout'
 import { TimeDiff } from '../TimeDiff'
 import { MessageFooter } from './Footer'
+import { AutoSummary } from '../AutoSummary'
 
 export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
     const { push } = useStack()
@@ -50,7 +51,9 @@ export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
             headerRight={<TimeDiff date={message.createdAt} />}
         >
             {message.value.body && (
-                <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
+                <AutoSummary body={message.value.body}>
+                    <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
+                </AutoSummary>
             )}
 
             {medias.length > 0 && (

--- a/app/src/components/message/ReplyMessage.tsx
+++ b/app/src/components/message/ReplyMessage.tsx
@@ -11,6 +11,7 @@ import { MessageLayout } from './MessageLayout'
 import { MessageContainer } from './main'
 import { TimeDiff } from '../TimeDiff'
 import { MessageFooter } from './Footer'
+import { AutoSummary } from '../AutoSummary'
 
 export const ReplyMessage = (props: MessageProps<ReplyMessageSchema>) => {
     const { push } = useStack()
@@ -49,7 +50,9 @@ export const ReplyMessage = (props: MessageProps<ReplyMessageSchema>) => {
                 }
                 headerRight={<TimeDiff date={props.message.createdAt} />}
             >
-                <CfmRenderer messagebody={props.message.value.body} emojiDict={props.message.value.emojis ?? {}} />
+                <AutoSummary body={props.message.value.body ?? ''}>
+                    <CfmRenderer messagebody={props.message.value.body} emojiDict={props.message.value.emojis ?? {}} />
+                </AutoSummary>
                 <MessageFooter message={props.message} />
             </MessageLayout>
         </div>

--- a/app/src/contexts/UrlSummary.tsx
+++ b/app/src/contexts/UrlSummary.tsx
@@ -1,0 +1,51 @@
+import { fetchWithTimeout } from '@concrnt/client'
+import { createContext, ReactNode, useCallback, useContext, useRef } from 'react'
+import { useClient } from './Client'
+
+export interface Summary {
+    title: string
+    icon: string
+    description: string
+    thumbnail: string
+    sitename: string
+    url: string
+}
+
+export interface UrlSummaryState {
+    getSummary: (url: string) => Promise<Summary | undefined>
+}
+
+const UrlSummaryContext = createContext<UrlSummaryState | undefined>(undefined)
+
+interface Props {
+    children: ReactNode
+}
+
+export const UrlSummaryProvider = (props: Props): ReactNode => {
+    const { client } = useClient()
+    const cache = useRef<Record<string, Promise<Summary | undefined>>>({})
+    const host = client.server.domain
+
+    const getSummary = useCallback(
+        async (url: string): Promise<Summary | undefined> => {
+            if (url in cache.current) return await cache.current[url]
+            const promise = fetchWithTimeout(`https://${host}/summary?url=${encodeURIComponent(url)}`, {})
+                .then(async (response) => {
+                    if (!response.ok) return undefined
+                    const json = await response.json()
+                    return json as Summary
+                })
+                .catch(() => undefined)
+
+            cache.current[url] = promise
+            return promise
+        },
+        [host]
+    )
+
+    return <UrlSummaryContext.Provider value={{ getSummary }}>{props.children}</UrlSummaryContext.Provider>
+}
+
+export function useUrlSummary(): UrlSummaryState | undefined {
+    return useContext(UrlSummaryContext)
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -21,6 +21,7 @@ import TickerProvider from './contexts/Ticer'
 import { ConfirmProvider } from './contexts/Confirm'
 import { EmojiPickerProvider } from './contexts/EmojiPicker'
 import { WelcomeView } from './views/Welcome'
+import { UrlSummaryProvider } from './contexts/UrlSummary'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <ErrorBoundary FallbackComponent={EmergencyKit}>
@@ -46,7 +47,9 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
                                                         <MediaViewerProvider>
                                                             <AudioPlayerProvider>
                                                                 <TickerProvider>
-                                                                    <App />
+                                                                    <UrlSummaryProvider>
+                                                                        <App />
+                                                                    </UrlSummaryProvider>
                                                                 </TickerProvider>
                                                             </AudioPlayerProvider>
                                                         </MediaViewerProvider>

--- a/web/src/components/AutoSummary.tsx
+++ b/web/src/components/AutoSummary.tsx
@@ -1,0 +1,181 @@
+import { ReactNode, useMemo } from 'react'
+import { UrlSummaryCard } from './UrlSummaryCard'
+
+interface Props {
+    body: string
+    limit?: number
+    children: ReactNode
+}
+
+function extractUrls(text: string): string[] {
+    // strip markdown image syntax
+    let replaced = text.replace(/!\[.*?\]\(.*?\)/g, '')
+
+    // strip codeblock
+    replaced = replaced.replace(/```[\s\S]*?```/g, '')
+
+    // strip inline code
+    replaced = replaced.replace(/`[\s\S]*?`/g, '')
+
+    // strip img tag
+    replaced = replaced.replace(/<img.*?>/g, '')
+
+    // strip social tag
+    replaced = replaced.replace(/<social.*?>.*?<\/social>/g, '')
+
+    // strip emojipack tag
+    replaced = replaced.replace(/<emojipack.*?\/>/g, '')
+
+    // replace markdown link syntax to just URL
+    replaced = replaced.replace(/\[.*?\]\((.*?)\)/g, '$1')
+
+    // strip a tag body
+    replaced = replaced.replace(/<a(.*?)>.*?<\/a>/g, '$1')
+
+    // extract urls
+    const urls = replaced.match(/(https?:\/\/[\w.\-?=/&%#,@+:!~]+)/g) ?? []
+
+    // deduplicate
+    return [...new Set(urls)]
+}
+
+export const AutoSummary = (props: Props) => {
+    const limit = props.limit ?? 1
+
+    const urls = useMemo(() => {
+        if (limit <= 0) return []
+        return extractUrls(props.body)
+    }, [props.body, limit])
+
+    return (
+        <>
+            {props.children}
+            {urls.slice(0, limit).map((url, i) => {
+                // YouTube embed
+                let matchYoutube = url.match(/https:\/\/www\.youtube\.com\/watch\?v=([a-zA-Z0-9_-]+)/)
+                if (!matchYoutube) matchYoutube = url.match(/https:\/\/youtu\.be\/([a-zA-Z0-9_-]+)/)
+                if (matchYoutube) {
+                    return (
+                        <div
+                            key={i}
+                            style={{
+                                aspectRatio: '16 / 9',
+                                overflow: 'hidden',
+                                width: '100%',
+                                borderRadius: '8px',
+                                marginTop: '4px',
+                                maxWidth: '500px'
+                            }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <iframe
+                                allowFullScreen
+                                src={`https://www.youtube.com/embed/${matchYoutube[1]}`}
+                                title="YouTube video player"
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                style={{
+                                    width: '100%',
+                                    height: '100%',
+                                    border: 'none'
+                                }}
+                            />
+                        </div>
+                    )
+                }
+
+                // Spotify embed
+                const matchSpotify = url.match(
+                    /https:\/\/open\.spotify\.com\/([-a-zA-Z0-9]+\/)?(track|album|playlist)\/([a-zA-Z0-9]+)/
+                )
+                if (matchSpotify) {
+                    const type = matchSpotify[2]
+                    const id = matchSpotify[3]
+                    return (
+                        <div
+                            key={i}
+                            style={{
+                                overflow: 'hidden',
+                                width: '100%',
+                                height: '152px',
+                                borderRadius: '8px',
+                                marginTop: '4px'
+                            }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <iframe
+                                allowFullScreen
+                                src={`https://open.spotify.com/embed/${type}/${id}`}
+                                style={{
+                                    width: '100%',
+                                    height: '100%',
+                                    border: 'none'
+                                }}
+                                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                            />
+                        </div>
+                    )
+                }
+
+                // Apple Music embed
+                const matchAppleMusic = url.match(/https:\/\/music\.apple\.com\/([^\s]+)/)
+                if (matchAppleMusic) {
+                    return (
+                        <div
+                            key={i}
+                            style={{
+                                overflow: 'hidden',
+                                width: '100%',
+                                height: '152px',
+                                borderRadius: '8px',
+                                marginTop: '4px'
+                            }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <iframe
+                                allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"
+                                sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation"
+                                src={`https://embed.music.apple.com/${matchAppleMusic[1]}`}
+                                style={{
+                                    width: '100%',
+                                    height: '100%',
+                                    border: 'none'
+                                }}
+                            />
+                        </div>
+                    )
+                }
+
+                // SoundCloud embed
+                const matchSoundcloud = url.match(/https:\/\/soundcloud\.com\/([^\s]+)/)
+                if (matchSoundcloud) {
+                    return (
+                        <div
+                            key={i}
+                            style={{
+                                overflow: 'hidden',
+                                width: '100%',
+                                height: '152px',
+                                borderRadius: '8px',
+                                marginTop: '4px'
+                            }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <iframe
+                                allowFullScreen
+                                src={`https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/${matchSoundcloud[1]}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true`}
+                                style={{
+                                    width: '100%',
+                                    height: '100%',
+                                    border: 'none'
+                                }}
+                            />
+                        </div>
+                    )
+                }
+
+                // Default: URL summary card
+                return <UrlSummaryCard key={i} url={url} />
+            })}
+        </>
+    )
+}

--- a/web/src/components/UrlSummaryCard.tsx
+++ b/web/src/components/UrlSummaryCard.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useState } from 'react'
+import { type Summary, useUrlSummary } from '../contexts/UrlSummary'
+import { CssVar } from '../types/Theme'
+
+interface Props {
+    url: string
+}
+
+export const UrlSummaryCard = (props: Props) => {
+    const service = useUrlSummary()
+    const [preview, setPreview] = useState<Summary | undefined>(undefined)
+    const [errored, setErrored] = useState(false)
+
+    useEffect(() => {
+        if (!service) return
+        service
+            .getSummary(props.url)
+            .then((summary) => {
+                if (summary) setPreview(summary)
+                else setErrored(true)
+            })
+            .catch(() => {
+                setErrored(true)
+            })
+    }, [props.url, service])
+
+    if (!service || errored) return null
+
+    let hostname = ''
+    try {
+        hostname = new URL(props.url).hostname
+    } catch {
+        hostname = props.url
+    }
+
+    if (!preview) {
+        return (
+            <div
+                style={{
+                    display: 'flex',
+                    height: '80px',
+                    width: '100%',
+                    overflow: 'hidden',
+                    borderRadius: CssVar.round(1),
+                    border: `1px solid ${CssVar.divider}`
+                }}
+            >
+                <div
+                    style={{
+                        width: '80px',
+                        height: '80px',
+                        flexShrink: 0,
+                        backgroundColor: CssVar.divider
+                    }}
+                />
+                <div
+                    style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '4px',
+                        padding: '8px',
+                        flex: 1,
+                        overflow: 'hidden'
+                    }}
+                >
+                    <div
+                        style={{
+                            height: '14px',
+                            width: '60%',
+                            backgroundColor: CssVar.divider,
+                            borderRadius: '4px'
+                        }}
+                    />
+                    <div
+                        style={{
+                            height: '12px',
+                            width: '90%',
+                            backgroundColor: CssVar.divider,
+                            borderRadius: '4px'
+                        }}
+                    />
+                    <div
+                        style={{
+                            height: '12px',
+                            width: '40%',
+                            backgroundColor: CssVar.divider,
+                            borderRadius: '4px'
+                        }}
+                    />
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <a
+            href={props.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => {
+                e.stopPropagation()
+            }}
+            style={{
+                display: 'flex',
+                height: '80px',
+                width: '100%',
+                overflow: 'hidden',
+                textDecoration: 'none',
+                color: 'inherit',
+                borderRadius: CssVar.round(1),
+                border: `1px solid ${CssVar.divider}`
+            }}
+        >
+            {(preview.thumbnail || preview.icon) && (
+                <div
+                    style={{
+                        width: '80px',
+                        height: '80px',
+                        backgroundSize: 'cover',
+                        backgroundPosition: 'center',
+                        backgroundImage: `url(${preview.thumbnail || preview.icon})`,
+                        flexShrink: 0
+                    }}
+                />
+            )}
+            <div
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    padding: '8px',
+                    height: '80px',
+                    overflow: 'hidden',
+                    flex: 1,
+                    gap: '2px',
+                    boxSizing: 'border-box'
+                }}
+            >
+                <div
+                    style={{
+                        fontWeight: 'bold',
+                        fontSize: '13px',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        lineHeight: 1.3
+                    }}
+                >
+                    {preview.title || hostname}
+                </div>
+                <div
+                    style={{
+                        fontSize: '12px',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        flex: 1,
+                        lineHeight: 1.3,
+                        opacity: 0.7,
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical'
+                    }}
+                >
+                    {preview.description || ''}
+                </div>
+                <div
+                    style={{
+                        fontSize: '11px',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        opacity: 0.5
+                    }}
+                >
+                    {hostname}
+                </div>
+            </div>
+        </a>
+    )
+}

--- a/web/src/components/message/MarkdownMessage.tsx
+++ b/web/src/components/message/MarkdownMessage.tsx
@@ -7,6 +7,7 @@ import { MessageLayout } from './MessageLayout'
 import { TimeDiff } from '../TimeDiff'
 import { useNavigate } from 'react-router-dom'
 import { MessageFooter } from './Footer'
+import { AutoSummary } from '../AutoSummary'
 
 export const MarkdownMessage = (props: MessageProps<MarkdownMessageSchema>) => {
     const navigate = useNavigate()
@@ -39,7 +40,9 @@ export const MarkdownMessage = (props: MessageProps<MarkdownMessageSchema>) => {
             }
             headerRight={<TimeDiff date={message.createdAt} />}
         >
-            <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
+            <AutoSummary body={message.value.body ?? ''}>
+                <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
+            </AutoSummary>
             <MessageFooter message={message} />
         </MessageLayout>
     )

--- a/web/src/components/message/MediaMessage.tsx
+++ b/web/src/components/message/MediaMessage.tsx
@@ -10,6 +10,7 @@ import { MessageLayout } from './MessageLayout'
 import { TimeDiff } from '../TimeDiff'
 import { useNavigate } from 'react-router-dom'
 import { MessageFooter } from './Footer'
+import { AutoSummary } from '../AutoSummary'
 
 export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
     const navigate = useNavigate()
@@ -47,7 +48,9 @@ export const MediaMessage = (props: MessageProps<MediaMessageSchema>) => {
             headerRight={<TimeDiff date={message.createdAt} />}
         >
             {message.value.body && (
-                <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
+                <AutoSummary body={message.value.body}>
+                    <CfmRenderer messagebody={message.value.body} emojiDict={message.value.emojis ?? {}} />
+                </AutoSummary>
             )}
 
             {medias.length > 0 && (

--- a/web/src/components/message/ReplyMessage.tsx
+++ b/web/src/components/message/ReplyMessage.tsx
@@ -8,6 +8,7 @@ import { MessageContainer } from './main'
 import { TimeDiff } from '../TimeDiff'
 import { useNavigate } from 'react-router-dom'
 import { MessageFooter } from './Footer'
+import { AutoSummary } from '../AutoSummary'
 
 export const ReplyMessage = (props: MessageProps<ReplyMessageSchema>) => {
     const navigate = useNavigate()
@@ -46,8 +47,9 @@ export const ReplyMessage = (props: MessageProps<ReplyMessageSchema>) => {
                 }
                 headerRight={<TimeDiff date={props.message.createdAt} />}
             >
-                <CfmRenderer messagebody={props.message.value.body} emojiDict={props.message.value.emojis ?? {}} />
-
+                <AutoSummary body={props.message.value.body ?? ''}>
+                    <CfmRenderer messagebody={props.message.value.body} emojiDict={props.message.value.emojis ?? {}} />
+                </AutoSummary>
                 <MessageFooter message={props.message} />
             </MessageLayout>
         </div>

--- a/web/src/contexts/UrlSummary.tsx
+++ b/web/src/contexts/UrlSummary.tsx
@@ -1,0 +1,51 @@
+import { fetchWithTimeout } from '@concrnt/client'
+import { createContext, ReactNode, useCallback, useContext, useRef } from 'react'
+import { useClient } from './Client'
+
+export interface Summary {
+    title: string
+    icon: string
+    description: string
+    thumbnail: string
+    sitename: string
+    url: string
+}
+
+export interface UrlSummaryState {
+    getSummary: (url: string) => Promise<Summary | undefined>
+}
+
+const UrlSummaryContext = createContext<UrlSummaryState | undefined>(undefined)
+
+interface Props {
+    children: ReactNode
+}
+
+export const UrlSummaryProvider = (props: Props): ReactNode => {
+    const { client } = useClient()
+    const cache = useRef<Record<string, Promise<Summary | undefined>>>({})
+    const host = client.server.domain
+
+    const getSummary = useCallback(
+        async (url: string): Promise<Summary | undefined> => {
+            if (url in cache.current) return await cache.current[url]
+            const promise = fetchWithTimeout(`https://${host}/summary?url=${encodeURIComponent(url)}`, {})
+                .then(async (response) => {
+                    if (!response.ok) return undefined
+                    const json = await response.json()
+                    return json as Summary
+                })
+                .catch(() => undefined)
+
+            cache.current[url] = promise
+            return promise
+        },
+        [host]
+    )
+
+    return <UrlSummaryContext.Provider value={{ getSummary }}>{props.children}</UrlSummaryContext.Provider>
+}
+
+export function useUrlSummary(): UrlSummaryState | undefined {
+    return useContext(UrlSummaryContext)
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -17,6 +17,7 @@ import { AudioPlayerProvider } from './contexts/AudioPlayer'
 import { ImageCropperProvider } from './contexts/ImageCropper'
 import TickerProvider from './contexts/Ticer'
 import { ConfirmProvider } from './contexts/Confirm'
+import { UrlSummaryProvider } from './contexts/UrlSummary'
 import { WelcomeView } from './views/Welcome'
 import { AppShell } from './pages/App'
 import { HomeView } from './views/Home'
@@ -66,40 +67,45 @@ const AuthedRoutes = () => (
                                 <MediaViewerProvider>
                                     <AudioPlayerProvider>
                                         <TickerProvider>
-                                            <Routes>
-                                                <Route path="/" element={<AppShell />}>
-                                                    <Route index element={<HomeView />} />
-                                                    <Route path="explorer" element={<ExplorerView />} />
-                                                    <Route path="notifications" element={<NotificationsView />} />
-                                                    <Route path="contacts" element={<ContactsView />} />
-                                                    <Route path="settings" element={<SettingsView />} />
-                                                    <Route path="profile/:ccid/:profile?" element={<ProfileRoute />} />
-                                                    <Route path="post/:uri" element={<UriRoute kind="post" />} />
-                                                    <Route
-                                                        path="timeline/:uri"
-                                                        element={<UriRoute kind="timeline" />}
-                                                    />
-                                                    <Route path="lists" element={<ListsView />} />
-                                                    <Route path="lists/:uri" element={<ListsView />} />
-                                                    <Route path="query" element={<QueryView />} />
-                                                    <Route path="dev" element={<DevView />} />
-                                                    <Route path="id" element={<IDView />} />
-                                                    <Route path="activitypub" element={<Activitypub />} />
-                                                    <Route
-                                                        path="activitypub/person/:uri"
-                                                        element={<UriRoute kind="apView" />}
-                                                    />
-                                                    <Route
-                                                        path="activitypub/note/:uri"
-                                                        element={<UriRoute kind="apView" />}
-                                                    />
-                                                    <Route
-                                                        path="activitypub/view/:uri"
-                                                        element={<UriRoute kind="apView" />}
-                                                    />
-                                                    <Route path="*" element={<Navigate to="/" replace />} />
-                                                </Route>
-                                            </Routes>
+                                            <UrlSummaryProvider>
+                                                <Routes>
+                                                    <Route path="/" element={<AppShell />}>
+                                                        <Route index element={<HomeView />} />
+                                                        <Route path="explorer" element={<ExplorerView />} />
+                                                        <Route path="notifications" element={<NotificationsView />} />
+                                                        <Route path="contacts" element={<ContactsView />} />
+                                                        <Route path="settings" element={<SettingsView />} />
+                                                        <Route
+                                                            path="profile/:ccid/:profile?"
+                                                            element={<ProfileRoute />}
+                                                        />
+                                                        <Route path="post/:uri" element={<UriRoute kind="post" />} />
+                                                        <Route
+                                                            path="timeline/:uri"
+                                                            element={<UriRoute kind="timeline" />}
+                                                        />
+                                                        <Route path="lists" element={<ListsView />} />
+                                                        <Route path="lists/:uri" element={<ListsView />} />
+                                                        <Route path="query" element={<QueryView />} />
+                                                        <Route path="dev" element={<DevView />} />
+                                                        <Route path="id" element={<IDView />} />
+                                                        <Route path="activitypub" element={<Activitypub />} />
+                                                        <Route
+                                                            path="activitypub/person/:uri"
+                                                            element={<UriRoute kind="apView" />}
+                                                        />
+                                                        <Route
+                                                            path="activitypub/note/:uri"
+                                                            element={<UriRoute kind="apView" />}
+                                                        />
+                                                        <Route
+                                                            path="activitypub/view/:uri"
+                                                            element={<UriRoute kind="apView" />}
+                                                        />
+                                                        <Route path="*" element={<Navigate to="/" replace />} />
+                                                    </Route>
+                                                </Routes>
+                                            </UrlSummaryProvider>
                                         </TickerProvider>
                                     </AudioPlayerProvider>
                                 </MediaViewerProvider>


### PR DESCRIPTION
resolve #72 

概要
メッセージ本文中のURLに対してプレビューカード (OGPカード) を表示する機能を実装しました。YouTube / Spotify / Apple Music / SoundCloud などの URL は専用の埋め込みプレイヤーで表示します。

変更内容
新規ファイル

- **`app/src/contexts/UrlSummary.tsx`**

  - サーバーの `/summary` エンドポイントからOGP情報 (タイトル、説明文、サムネイル等) を取得するサービスContext
  - `useClient()` で `server.domain` を取得し、レスポンスをインメモリキャッシュ


- **`app/src/components/AutoSummary.tsx`**

  - メッセージ本文 (raw text) からURLを抽出し、プレビューを描画するコンポーネント
  - Markdown のコードブロック・画像構文・social タグ等を除外してから URL 抽出
  - YouTube / Spotify / Apple Music / SoundCloud など → 専用 iframe 埋め込み
  - その他 → `UrlSummaryCard` で OGP カード表示
  - `limit prop` でプレビュー数を制御 (デフォルト1)


- **`app/src/components/UrlSummaryCard.tsx`**

  - サムネイル + タイトル + 説明文 + ホスト名を表示するカードUI
  - ローディング中はスケルトン表示、取得失敗時は非表示



変更ファイル

- **`app/src/main.tsx`** — `UrlSummaryProvider` をプロバイダーツリーに追加
- **`app/src/components/message/MarkdownMessage.tsx`** — `AutoSummary` で `CfmRenderer` をラップ
- **`app/src/components/message/MediaMessage.tsx`** — 同上
- **`app/src/components/message/ReplyMessage.tsx`** — 同上