### PR TITLE
絵文字のショートコードのサジェストを実装しました

### DIFF
--- a/app/src/components/Composer.tsx
+++ b/app/src/components/Composer.tsx
@@ -47,34 +47,6 @@ export const Composer = (props: Props) => {
     const theme = useTheme()
     const emojiPicker = useEmojiPicker()
 
-    // 手打ちショートコードの自動解決（emojiDictRefで無限ループ回避）
-    const emojiDictRef = useRef(emojiDict)
-    emojiDictRef.current = emojiDict
-
-    useEffect(() => {
-        const shortcodeRegex = /:([\w+-]+):/g
-        const matches = [...draft.matchAll(shortcodeRegex)]
-        if (matches.length === 0) return
-
-        const currentDict = emojiDictRef.current
-        const newEntries: Record<string, { imageURL: string }> = {}
-        for (const match of matches) {
-            const code = match[1]
-            if (currentDict[code]) continue
-            for (const pkg of emojiPicker.packages) {
-                const found = pkg.emojis.find((e) => e.shortcode === code)
-                if (found) {
-                    newEntries[code] = { imageURL: found.imageURL }
-                    break
-                }
-            }
-        }
-
-        if (Object.keys(newEntries).length > 0) {
-            setEmojiDict((prev) => ({ ...prev, ...newEntries }))
-        }
-    }, [draft, emojiPicker.packages])
-
     const [viewportHeight, setViewportHeight] = useLocalStorage<number>(
         'composerViewportHeight',
         visualViewport?.height ?? 0

--- a/app/src/components/Composer.tsx
+++ b/app/src/components/Composer.tsx
@@ -15,6 +15,7 @@ import { hapticSuccess } from '../utils/haptics'
 import { MdSend } from 'react-icons/md'
 import { MdEmojiEmotions } from 'react-icons/md'
 import { useEmojiPicker, Emoji } from '../contexts/EmojiPicker'
+import { EmojiSuggestion } from './EmojiSuggestion'
 import { MdOutlineUploadFile } from 'react-icons/md'
 import { CDID } from '@concrnt/client'
 
@@ -45,6 +46,34 @@ export const Composer = (props: Props) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const theme = useTheme()
     const emojiPicker = useEmojiPicker()
+
+    // 手打ちショートコードの自動解決（emojiDictRefで無限ループ回避）
+    const emojiDictRef = useRef(emojiDict)
+    emojiDictRef.current = emojiDict
+
+    useEffect(() => {
+        const shortcodeRegex = /:([\w+-]+):/g
+        const matches = [...draft.matchAll(shortcodeRegex)]
+        if (matches.length === 0) return
+
+        const currentDict = emojiDictRef.current
+        const newEntries: Record<string, { imageURL: string }> = {}
+        for (const match of matches) {
+            const code = match[1]
+            if (currentDict[code]) continue
+            for (const pkg of emojiPicker.packages) {
+                const found = pkg.emojis.find((e) => e.shortcode === code)
+                if (found) {
+                    newEntries[code] = { imageURL: found.imageURL }
+                    break
+                }
+            }
+        }
+
+        if (Object.keys(newEntries).length > 0) {
+            setEmojiDict((prev) => ({ ...prev, ...newEntries }))
+        }
+    }, [draft, emojiPicker.packages])
 
     const [viewportHeight, setViewportHeight] = useLocalStorage<number>(
         'composerViewportHeight',
@@ -410,6 +439,16 @@ export const Composer = (props: Props) => {
                                         }}
                                     />
                                 </div>
+                            )}
+
+                            {/* 絵文字サジェスト */}
+                            {props.mode !== 'reroute' && (
+                                <EmojiSuggestion
+                                    textareaRef={textareaRef}
+                                    text={draft}
+                                    setText={setDraft}
+                                    updateEmojiDict={setEmojiDict}
+                                />
                             )}
 
                             {/* テキストプレビュー（絵文字等のレンダリング確認用） */}

--- a/app/src/components/EmojiSuggestion.tsx
+++ b/app/src/components/EmojiSuggestion.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useMemo, useState } from 'react'
+import { AnimatePresence, motion } from 'motion/react'
+import { useEmojiPicker, Emoji } from '../contexts/EmojiPicker'
+import { CssVar } from '../types/Theme'
+
+interface Props {
+    textareaRef: React.RefObject<HTMLTextAreaElement | null>
+    text: string
+    setText: (text: string) => void
+    updateEmojiDict: React.Dispatch<React.SetStateAction<Record<string, { imageURL: string }>>>
+}
+
+export const EmojiSuggestion = (props: Props) => {
+    const emojiPicker = useEmojiPicker()
+
+    const [cursorPos, setCursorPos] = useState<number>(0)
+    const [forceOff, setForceOff] = useState(false)
+
+    // カーソル位置を追跡
+    useEffect(() => {
+        const ta = props.textareaRef.current
+        if (!ta) return
+
+        const updateCursor = () => {
+            setCursorPos(ta.selectionEnd ?? 0)
+            setForceOff(false)
+        }
+
+        ta.addEventListener('input', updateCursor)
+        ta.addEventListener('click', updateCursor)
+        ta.addEventListener('keyup', updateCursor)
+
+        return () => {
+            ta.removeEventListener('input', updateCursor)
+            ta.removeEventListener('click', updateCursor)
+            ta.removeEventListener('keyup', updateCursor)
+        }
+    }, [props.textareaRef])
+
+    // カーソル前のテキストから `:query` パターンを検出
+    const query = useMemo(() => {
+        const before = props.text.slice(0, cursorPos)
+        const match = /:(\w+)$/.exec(before)
+        return match?.[1] ?? null
+    }, [props.text, cursorPos])
+
+    // 検索結果
+    const suggestions = useMemo(() => {
+        if (!query) return []
+        return emojiPicker.search(query, 16)
+    }, [query, emojiPicker])
+
+    const showSuggestions = query !== null && suggestions.length > 0 && !forceOff
+
+    const onConfirm = (emoji: Emoji) => {
+        const before = props.text.slice(0, cursorPos)
+        const after = props.text.slice(cursorPos)
+        const colonPos = before.lastIndexOf(':')
+        if (colonPos === -1) return
+
+        const newText = before.slice(0, colonPos) + `:${emoji.shortcode}: ` + after
+        props.setText(newText)
+
+        props.updateEmojiDict((prev) => ({
+            ...prev,
+            [emoji.shortcode]: { imageURL: emoji.imageURL }
+        }))
+
+        setForceOff(true)
+
+        // カーソルを挿入位置の後ろに移動
+        requestAnimationFrame(() => {
+            const ta = props.textareaRef.current
+            if (ta) {
+                const newPos = colonPos + emoji.shortcode.length + 3 // `:shortcode: ` の長さ
+                ta.setSelectionRange(newPos, newPos)
+                ta.focus()
+            }
+        })
+    }
+
+    return (
+        <AnimatePresence>
+            {showSuggestions && (
+                <motion.div
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: 'auto' }}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={{ duration: 0.15 }}
+                    style={{ overflow: 'hidden' }}
+                >
+                    <div
+                        style={{
+                            display: 'flex',
+                            overflowX: 'auto',
+                            gap: CssVar.space(1),
+                            padding: `${CssVar.space(1)} 0`,
+                            WebkitOverflowScrolling: 'touch'
+                        }}
+                    >
+                        {suggestions.map((emoji) => (
+                            <button
+                                key={emoji.shortcode}
+                                onMouseDown={(e) => {
+                                    e.preventDefault() // textareaのblurを防ぐ
+                                    onConfirm(emoji)
+                                }}
+                                style={{
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    alignItems: 'center',
+                                    gap: '2px',
+                                    padding: CssVar.space(1),
+                                    border: 'none',
+                                    background: `rgb(from ${CssVar.contentText} r g b / 0.06)`,
+                                    borderRadius: CssVar.round(0.5),
+                                    cursor: 'pointer',
+                                    flexShrink: 0,
+                                    WebkitTapHighlightColor: 'transparent',
+                                    color: CssVar.contentText
+                                }}
+                            >
+                                <img
+                                    src={emoji.imageURL}
+                                    alt={emoji.shortcode}
+                                    style={{ width: '28px', height: '28px' }}
+                                />
+                                <span
+                                    style={{
+                                        fontSize: '10px',
+                                        opacity: 0.6,
+                                        maxWidth: '56px',
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        whiteSpace: 'nowrap'
+                                    }}
+                                >
+                                    {emoji.shortcode}
+                                </span>
+                            </button>
+                        ))}
+                    </div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    )
+}

--- a/app/src/components/EmojiSuggestion.tsx
+++ b/app/src/components/EmojiSuggestion.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
-import { useEmojiPicker, Emoji } from '../contexts/EmojiPicker'
+import { useEmojiPicker } from '../contexts/EmojiPicker'
 import { CssVar } from '../types/Theme'
 
 interface Props {
@@ -10,39 +10,19 @@ interface Props {
     updateEmojiDict: React.Dispatch<React.SetStateAction<Record<string, { imageURL: string }>>>
 }
 
-export const EmojiSuggestion = (props: Props) => {
+export const EmojiSuggestion = ({ textareaRef, text, setText, updateEmojiDict }: Props) => {
     const emojiPicker = useEmojiPicker()
 
     const [cursorPos, setCursorPos] = useState<number>(0)
     const [forceOff, setForceOff] = useState(false)
-
-    // カーソル位置を追跡
-    useEffect(() => {
-        const ta = props.textareaRef.current
-        if (!ta) return
-
-        const updateCursor = () => {
-            setCursorPos(ta.selectionEnd ?? 0)
-            setForceOff(false)
-        }
-
-        ta.addEventListener('input', updateCursor)
-        ta.addEventListener('click', updateCursor)
-        ta.addEventListener('keyup', updateCursor)
-
-        return () => {
-            ta.removeEventListener('input', updateCursor)
-            ta.removeEventListener('click', updateCursor)
-            ta.removeEventListener('keyup', updateCursor)
-        }
-    }, [props.textareaRef])
+    const [selectedIndex, setSelectedIndex] = useState<number>(0)
 
     // カーソル前のテキストから `:query` パターンを検出
     const query = useMemo(() => {
-        const before = props.text.slice(0, cursorPos)
+        const before = text.slice(0, cursorPos)
         const match = /:(\w+)$/.exec(before)
         return match?.[1] ?? null
-    }, [props.text, cursorPos])
+    }, [text, cursorPos])
 
     // 検索結果
     const suggestions = useMemo(() => {
@@ -52,32 +32,108 @@ export const EmojiSuggestion = (props: Props) => {
 
     const showSuggestions = query !== null && suggestions.length > 0 && !forceOff
 
-    const onConfirm = (emoji: Emoji) => {
-        const before = props.text.slice(0, cursorPos)
-        const after = props.text.slice(cursorPos)
-        const colonPos = before.lastIndexOf(':')
-        if (colonPos === -1) return
-
-        const newText = before.slice(0, colonPos) + `:${emoji.shortcode}: ` + after
-        props.setText(newText)
-
-        props.updateEmojiDict((prev) => ({
-            ...prev,
-            [emoji.shortcode]: { imageURL: emoji.imageURL }
-        }))
-
-        setForceOff(true)
-
-        // カーソルを挿入位置の後ろに移動
-        requestAnimationFrame(() => {
-            const ta = props.textareaRef.current
-            if (ta) {
-                const newPos = colonPos + emoji.shortcode.length + 3 // `:shortcode: ` の長さ
-                ta.setSelectionRange(newPos, newPos)
-                ta.focus()
-            }
-        })
+    // query が変わったら選択をリセット（レンダー中のstate調整パターン）
+    const [prevQuery, setPrevQuery] = useState(query)
+    if (query !== prevQuery) {
+        setPrevQuery(query)
+        setSelectedIndex(0)
     }
+
+    const onConfirm = useCallback(
+        (index: number) => {
+            const before = text.slice(0, cursorPos)
+            const after = text.slice(cursorPos)
+            const colonPos = before.lastIndexOf(':')
+            if (colonPos === -1) return
+
+            const emoji = suggestions[index]
+            if (!emoji) return
+
+            const newText = before.slice(0, colonPos) + `:${emoji.shortcode}: ` + after
+            setText(newText)
+            setSelectedIndex(0)
+
+            updateEmojiDict((prev) => ({
+                ...prev,
+                [emoji.shortcode]: { imageURL: emoji.imageURL }
+            }))
+
+            setForceOff(true)
+
+            // カーソルを挿入位置の後ろに移動
+            requestAnimationFrame(() => {
+                const ta = textareaRef.current
+                if (ta) {
+                    const newPos = colonPos + emoji.shortcode.length + 3
+                    ta.setSelectionRange(newPos, newPos)
+                    ta.focus()
+                }
+            })
+        },
+        [text, cursorPos, suggestions, textareaRef, setText, updateEmojiDict]
+    )
+
+    // カーソル位置の追跡
+    useEffect(() => {
+        const ta = textareaRef.current
+        if (!ta) return
+
+        const updateCursor = () => {
+            setCursorPos(ta.selectionEnd ?? 0)
+            setForceOff(false)
+        }
+
+        ta.addEventListener('input', updateCursor)
+        ta.addEventListener('click', updateCursor)
+
+        return () => {
+            ta.removeEventListener('input', updateCursor)
+            ta.removeEventListener('click', updateCursor)
+        }
+    }, [textareaRef])
+
+    // keydown: Enter確定 + 矢印キー移動（サジェスト表示中のみ）
+    const onKeyDown = useCallback(
+        (e: KeyboardEvent) => {
+            setForceOff(false)
+            if (!showSuggestions) return
+
+            if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+                e.preventDefault()
+                setSelectedIndex((prev) => (prev - 1 + suggestions.length) % suggestions.length)
+                return
+            }
+            if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+                e.preventDefault()
+                setSelectedIndex((prev) => (prev + 1) % suggestions.length)
+                return
+            }
+            if (e.key === 'Enter') {
+                e.preventDefault()
+                onConfirm(selectedIndex)
+            }
+        },
+        [showSuggestions, suggestions.length, selectedIndex, onConfirm]
+    )
+
+    const onBlur = useCallback(() => {
+        setTimeout(() => {
+            setForceOff(true)
+        }, 100)
+    }, [])
+
+    useEffect(() => {
+        const ta = textareaRef.current
+        if (!ta) return
+
+        ta.addEventListener('keydown', onKeyDown)
+        ta.addEventListener('blur', onBlur)
+
+        return () => {
+            ta.removeEventListener('keydown', onKeyDown)
+            ta.removeEventListener('blur', onBlur)
+        }
+    }, [textareaRef, onKeyDown, onBlur])
 
     return (
         <AnimatePresence>
@@ -98,12 +154,12 @@ export const EmojiSuggestion = (props: Props) => {
                             WebkitOverflowScrolling: 'touch'
                         }}
                     >
-                        {suggestions.map((emoji) => (
+                        {suggestions.map((emoji, index) => (
                             <button
                                 key={emoji.shortcode}
                                 onMouseDown={(e) => {
-                                    e.preventDefault() // textareaのblurを防ぐ
-                                    onConfirm(emoji)
+                                    e.preventDefault()
+                                    onConfirm(index)
                                 }}
                                 style={{
                                     display: 'flex',
@@ -111,7 +167,10 @@ export const EmojiSuggestion = (props: Props) => {
                                     alignItems: 'center',
                                     gap: '2px',
                                     padding: CssVar.space(1),
-                                    border: 'none',
+                                    border:
+                                        index === selectedIndex
+                                            ? `2px solid ${CssVar.contentLink}`
+                                            : '2px solid transparent',
                                     background: `rgb(from ${CssVar.contentText} r g b / 0.06)`,
                                     borderRadius: CssVar.round(0.5),
                                     cursor: 'pointer',

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -47,34 +47,6 @@ export const Composer = (props: Props) => {
     const theme = useTheme()
     const emojiPicker = useEmojiPicker()
 
-    // 手打ちショートコードの自動解決（emojiDictRefで無限ループ回避）
-    const emojiDictRef = useRef(emojiDict)
-    emojiDictRef.current = emojiDict
-
-    useEffect(() => {
-        const shortcodeRegex = /:([\w+-]+):/g
-        const matches = [...draft.matchAll(shortcodeRegex)]
-        if (matches.length === 0) return
-
-        const currentDict = emojiDictRef.current
-        const newEntries: Record<string, { imageURL: string }> = {}
-        for (const match of matches) {
-            const code = match[1]
-            if (currentDict[code]) continue
-            for (const pkg of emojiPicker.packages) {
-                const found = pkg.emojis.find((e) => e.shortcode === code)
-                if (found) {
-                    newEntries[code] = { imageURL: found.imageURL }
-                    break
-                }
-            }
-        }
-
-        if (Object.keys(newEntries).length > 0) {
-            setEmojiDict((prev) => ({ ...prev, ...newEntries }))
-        }
-    }, [draft, emojiPicker.packages])
-
     const [viewportHeight, setViewportHeight] = useLocalStorage<number>(
         'composerViewportHeight',
         visualViewport?.height ?? 0

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -15,6 +15,7 @@ import { hapticSuccess } from '../utils/haptics'
 import { MdSend } from 'react-icons/md'
 import { MdEmojiEmotions } from 'react-icons/md'
 import { useEmojiPicker, Emoji } from '../contexts/EmojiPicker'
+import { EmojiSuggestion } from './EmojiSuggestion'
 import { MdOutlineUploadFile } from 'react-icons/md'
 import { CDID } from '@concrnt/client'
 
@@ -45,6 +46,34 @@ export const Composer = (props: Props) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const theme = useTheme()
     const emojiPicker = useEmojiPicker()
+
+    // 手打ちショートコードの自動解決（emojiDictRefで無限ループ回避）
+    const emojiDictRef = useRef(emojiDict)
+    emojiDictRef.current = emojiDict
+
+    useEffect(() => {
+        const shortcodeRegex = /:([\w+-]+):/g
+        const matches = [...draft.matchAll(shortcodeRegex)]
+        if (matches.length === 0) return
+
+        const currentDict = emojiDictRef.current
+        const newEntries: Record<string, { imageURL: string }> = {}
+        for (const match of matches) {
+            const code = match[1]
+            if (currentDict[code]) continue
+            for (const pkg of emojiPicker.packages) {
+                const found = pkg.emojis.find((e) => e.shortcode === code)
+                if (found) {
+                    newEntries[code] = { imageURL: found.imageURL }
+                    break
+                }
+            }
+        }
+
+        if (Object.keys(newEntries).length > 0) {
+            setEmojiDict((prev) => ({ ...prev, ...newEntries }))
+        }
+    }, [draft, emojiPicker.packages])
 
     const [viewportHeight, setViewportHeight] = useLocalStorage<number>(
         'composerViewportHeight',
@@ -410,6 +439,16 @@ export const Composer = (props: Props) => {
                                         }}
                                     />
                                 </div>
+                            )}
+
+                            {/* 絵文字サジェスト */}
+                            {props.mode !== 'reroute' && (
+                                <EmojiSuggestion
+                                    textareaRef={textareaRef}
+                                    text={draft}
+                                    setText={setDraft}
+                                    updateEmojiDict={setEmojiDict}
+                                />
                             )}
 
                             {/* テキストプレビュー（絵文字等のレンダリング確認用） */}

--- a/web/src/components/EmojiSuggestion.tsx
+++ b/web/src/components/EmojiSuggestion.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useMemo, useState } from 'react'
+import { AnimatePresence, motion } from 'motion/react'
+import { useEmojiPicker, Emoji } from '../contexts/EmojiPicker'
+import { CssVar } from '../types/Theme'
+
+interface Props {
+    textareaRef: React.RefObject<HTMLTextAreaElement | null>
+    text: string
+    setText: (text: string) => void
+    updateEmojiDict: React.Dispatch<React.SetStateAction<Record<string, { imageURL: string }>>>
+}
+
+export const EmojiSuggestion = (props: Props) => {
+    const emojiPicker = useEmojiPicker()
+
+    const [cursorPos, setCursorPos] = useState<number>(0)
+    const [forceOff, setForceOff] = useState(false)
+
+    // カーソル位置を追跡
+    useEffect(() => {
+        const ta = props.textareaRef.current
+        if (!ta) return
+
+        const updateCursor = () => {
+            setCursorPos(ta.selectionEnd ?? 0)
+            setForceOff(false)
+        }
+
+        ta.addEventListener('input', updateCursor)
+        ta.addEventListener('click', updateCursor)
+        ta.addEventListener('keyup', updateCursor)
+
+        return () => {
+            ta.removeEventListener('input', updateCursor)
+            ta.removeEventListener('click', updateCursor)
+            ta.removeEventListener('keyup', updateCursor)
+        }
+    }, [props.textareaRef])
+
+    // カーソル前のテキストから `:query` パターンを検出
+    const query = useMemo(() => {
+        const before = props.text.slice(0, cursorPos)
+        const match = /:(\w+)$/.exec(before)
+        return match?.[1] ?? null
+    }, [props.text, cursorPos])
+
+    // 検索結果
+    const suggestions = useMemo(() => {
+        if (!query) return []
+        return emojiPicker.search(query, 16)
+    }, [query, emojiPicker])
+
+    const showSuggestions = query !== null && suggestions.length > 0 && !forceOff
+
+    const onConfirm = (emoji: Emoji) => {
+        const before = props.text.slice(0, cursorPos)
+        const after = props.text.slice(cursorPos)
+        const colonPos = before.lastIndexOf(':')
+        if (colonPos === -1) return
+
+        const newText = before.slice(0, colonPos) + `:${emoji.shortcode}: ` + after
+        props.setText(newText)
+
+        props.updateEmojiDict((prev) => ({
+            ...prev,
+            [emoji.shortcode]: { imageURL: emoji.imageURL }
+        }))
+
+        setForceOff(true)
+
+        // カーソルを挿入位置の後ろに移動
+        requestAnimationFrame(() => {
+            const ta = props.textareaRef.current
+            if (ta) {
+                const newPos = colonPos + emoji.shortcode.length + 3 // `:shortcode: ` の長さ
+                ta.setSelectionRange(newPos, newPos)
+                ta.focus()
+            }
+        })
+    }
+
+    return (
+        <AnimatePresence>
+            {showSuggestions && (
+                <motion.div
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: 'auto' }}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={{ duration: 0.15 }}
+                    style={{ overflow: 'hidden' }}
+                >
+                    <div
+                        style={{
+                            display: 'flex',
+                            overflowX: 'auto',
+                            gap: CssVar.space(1),
+                            padding: `${CssVar.space(1)} 0`,
+                            WebkitOverflowScrolling: 'touch'
+                        }}
+                    >
+                        {suggestions.map((emoji) => (
+                            <button
+                                key={emoji.shortcode}
+                                onMouseDown={(e) => {
+                                    e.preventDefault() // textareaのblurを防ぐ
+                                    onConfirm(emoji)
+                                }}
+                                style={{
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    alignItems: 'center',
+                                    gap: '2px',
+                                    padding: CssVar.space(1),
+                                    border: 'none',
+                                    background: `rgb(from ${CssVar.contentText} r g b / 0.06)`,
+                                    borderRadius: CssVar.round(0.5),
+                                    cursor: 'pointer',
+                                    flexShrink: 0,
+                                    WebkitTapHighlightColor: 'transparent',
+                                    color: CssVar.contentText
+                                }}
+                            >
+                                <img
+                                    src={emoji.imageURL}
+                                    alt={emoji.shortcode}
+                                    style={{ width: '28px', height: '28px' }}
+                                />
+                                <span
+                                    style={{
+                                        fontSize: '10px',
+                                        opacity: 0.6,
+                                        maxWidth: '56px',
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        whiteSpace: 'nowrap'
+                                    }}
+                                >
+                                    {emoji.shortcode}
+                                </span>
+                            </button>
+                        ))}
+                    </div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    )
+}

--- a/web/src/components/EmojiSuggestion.tsx
+++ b/web/src/components/EmojiSuggestion.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
-import { useEmojiPicker, Emoji } from '../contexts/EmojiPicker'
+import { useEmojiPicker } from '../contexts/EmojiPicker'
 import { CssVar } from '../types/Theme'
 
 interface Props {
@@ -10,39 +10,19 @@ interface Props {
     updateEmojiDict: React.Dispatch<React.SetStateAction<Record<string, { imageURL: string }>>>
 }
 
-export const EmojiSuggestion = (props: Props) => {
+export const EmojiSuggestion = ({ textareaRef, text, setText, updateEmojiDict }: Props) => {
     const emojiPicker = useEmojiPicker()
 
     const [cursorPos, setCursorPos] = useState<number>(0)
     const [forceOff, setForceOff] = useState(false)
-
-    // カーソル位置を追跡
-    useEffect(() => {
-        const ta = props.textareaRef.current
-        if (!ta) return
-
-        const updateCursor = () => {
-            setCursorPos(ta.selectionEnd ?? 0)
-            setForceOff(false)
-        }
-
-        ta.addEventListener('input', updateCursor)
-        ta.addEventListener('click', updateCursor)
-        ta.addEventListener('keyup', updateCursor)
-
-        return () => {
-            ta.removeEventListener('input', updateCursor)
-            ta.removeEventListener('click', updateCursor)
-            ta.removeEventListener('keyup', updateCursor)
-        }
-    }, [props.textareaRef])
+    const [selectedIndex, setSelectedIndex] = useState<number>(0)
 
     // カーソル前のテキストから `:query` パターンを検出
     const query = useMemo(() => {
-        const before = props.text.slice(0, cursorPos)
+        const before = text.slice(0, cursorPos)
         const match = /:(\w+)$/.exec(before)
         return match?.[1] ?? null
-    }, [props.text, cursorPos])
+    }, [text, cursorPos])
 
     // 検索結果
     const suggestions = useMemo(() => {
@@ -52,32 +32,108 @@ export const EmojiSuggestion = (props: Props) => {
 
     const showSuggestions = query !== null && suggestions.length > 0 && !forceOff
 
-    const onConfirm = (emoji: Emoji) => {
-        const before = props.text.slice(0, cursorPos)
-        const after = props.text.slice(cursorPos)
-        const colonPos = before.lastIndexOf(':')
-        if (colonPos === -1) return
-
-        const newText = before.slice(0, colonPos) + `:${emoji.shortcode}: ` + after
-        props.setText(newText)
-
-        props.updateEmojiDict((prev) => ({
-            ...prev,
-            [emoji.shortcode]: { imageURL: emoji.imageURL }
-        }))
-
-        setForceOff(true)
-
-        // カーソルを挿入位置の後ろに移動
-        requestAnimationFrame(() => {
-            const ta = props.textareaRef.current
-            if (ta) {
-                const newPos = colonPos + emoji.shortcode.length + 3 // `:shortcode: ` の長さ
-                ta.setSelectionRange(newPos, newPos)
-                ta.focus()
-            }
-        })
+    // query が変わったら選択をリセット（レンダー中のstate調整パターン）
+    const [prevQuery, setPrevQuery] = useState(query)
+    if (query !== prevQuery) {
+        setPrevQuery(query)
+        setSelectedIndex(0)
     }
+
+    const onConfirm = useCallback(
+        (index: number) => {
+            const before = text.slice(0, cursorPos)
+            const after = text.slice(cursorPos)
+            const colonPos = before.lastIndexOf(':')
+            if (colonPos === -1) return
+
+            const emoji = suggestions[index]
+            if (!emoji) return
+
+            const newText = before.slice(0, colonPos) + `:${emoji.shortcode}: ` + after
+            setText(newText)
+            setSelectedIndex(0)
+
+            updateEmojiDict((prev) => ({
+                ...prev,
+                [emoji.shortcode]: { imageURL: emoji.imageURL }
+            }))
+
+            setForceOff(true)
+
+            // カーソルを挿入位置の後ろに移動
+            requestAnimationFrame(() => {
+                const ta = textareaRef.current
+                if (ta) {
+                    const newPos = colonPos + emoji.shortcode.length + 3
+                    ta.setSelectionRange(newPos, newPos)
+                    ta.focus()
+                }
+            })
+        },
+        [text, cursorPos, suggestions, textareaRef, setText, updateEmojiDict]
+    )
+
+    // カーソル位置の追跡
+    useEffect(() => {
+        const ta = textareaRef.current
+        if (!ta) return
+
+        const updateCursor = () => {
+            setCursorPos(ta.selectionEnd ?? 0)
+            setForceOff(false)
+        }
+
+        ta.addEventListener('input', updateCursor)
+        ta.addEventListener('click', updateCursor)
+
+        return () => {
+            ta.removeEventListener('input', updateCursor)
+            ta.removeEventListener('click', updateCursor)
+        }
+    }, [textareaRef])
+
+    // keydown: Enter確定 + 矢印キー移動（サジェスト表示中のみ）
+    const onKeyDown = useCallback(
+        (e: KeyboardEvent) => {
+            setForceOff(false)
+            if (!showSuggestions) return
+
+            if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+                e.preventDefault()
+                setSelectedIndex((prev) => (prev - 1 + suggestions.length) % suggestions.length)
+                return
+            }
+            if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+                e.preventDefault()
+                setSelectedIndex((prev) => (prev + 1) % suggestions.length)
+                return
+            }
+            if (e.key === 'Enter') {
+                e.preventDefault()
+                onConfirm(selectedIndex)
+            }
+        },
+        [showSuggestions, suggestions.length, selectedIndex, onConfirm]
+    )
+
+    const onBlur = useCallback(() => {
+        setTimeout(() => {
+            setForceOff(true)
+        }, 100)
+    }, [])
+
+    useEffect(() => {
+        const ta = textareaRef.current
+        if (!ta) return
+
+        ta.addEventListener('keydown', onKeyDown)
+        ta.addEventListener('blur', onBlur)
+
+        return () => {
+            ta.removeEventListener('keydown', onKeyDown)
+            ta.removeEventListener('blur', onBlur)
+        }
+    }, [textareaRef, onKeyDown, onBlur])
 
     return (
         <AnimatePresence>
@@ -98,12 +154,12 @@ export const EmojiSuggestion = (props: Props) => {
                             WebkitOverflowScrolling: 'touch'
                         }}
                     >
-                        {suggestions.map((emoji) => (
+                        {suggestions.map((emoji, index) => (
                             <button
                                 key={emoji.shortcode}
                                 onMouseDown={(e) => {
-                                    e.preventDefault() // textareaのblurを防ぐ
-                                    onConfirm(emoji)
+                                    e.preventDefault()
+                                    onConfirm(index)
                                 }}
                                 style={{
                                     display: 'flex',
@@ -111,7 +167,10 @@ export const EmojiSuggestion = (props: Props) => {
                                     alignItems: 'center',
                                     gap: '2px',
                                     padding: CssVar.space(1),
-                                    border: 'none',
+                                    border:
+                                        index === selectedIndex
+                                            ? `2px solid ${CssVar.contentLink}`
+                                            : '2px solid transparent',
                                     background: `rgb(from ${CssVar.contentText} r g b / 0.06)`,
                                     borderRadius: CssVar.round(0.5),
                                     cursor: 'pointer',


### PR DESCRIPTION
## 概要
 
投稿作成中に `:shortcode` を手入力すると絵文字の候補がサジェスト表示され、タップで補完できるようになります。また、手打ちで完全な `:shortcode:` を入力した場合も、絵文字パッケージから自動で解決してプレビューに反映されます。
 
## 変更内容
 
### 1. 絵文字サジェスト (`EmojiSuggestion.tsx`) — 新規
 
- テキストエリアのカーソル位置を `input` / `click` / `keyup` イベントで追跡
- カーソル直前のテキストを `/:(\w+)$/` で検査し、`:xxx` パターンを検出
- `emojiPicker.search()` で候補を取得し、水平スクロール可能なストリップとして表示
- タップすると `:shortcode: ` に補完され、`emojiDict` にも自動登録
- `onMouseDown` で `preventDefault()` して textarea の blur を防止
- `requestAnimationFrame` でカーソル位置を補完後の正しい位置に設定
### 2. 手打ちショートコードの自動解決 (`Composer.tsx`) — 変更
 
- `draft` の変更を監視し、`:shortcode:` パターンを正規表現で検出
- `emojiPicker.packages` から完全一致で検索し、見つかった絵文字を `emojiDict` に追加
- `emojiDictRef` を使って `emojiDict` を deps から外し、無限ループを回避
### 変更ファイル
 
| ファイル | 種別 |
|---|---|
| `app/src/components/EmojiSuggestion.tsx` | 新規 |
| `app/src/components/Composer.tsx` | 変更 |
| `web/src/components/EmojiSuggestion.tsx` | 新規 |
| `web/src/components/Composer.tsx` | 変更 |