### PR TITLE
ヘッダーをタップすることによる Scroll to Top に対応しました

### DIFF
--- a/app/src/ui/Header.tsx
+++ b/app/src/ui/Header.tsx
@@ -7,6 +7,7 @@ interface Props {
     children?: ReactNode
     leftOverride?: ReactNode
     right?: ReactNode
+    onTitleTap?: () => void
 }
 
 export const Header = (props: Props) => {
@@ -39,8 +40,10 @@ export const Header = (props: Props) => {
                 style={{
                     flexGrow: 1,
                     textAlign: 'center',
-                    fontWeight: 'bold'
+                    fontWeight: 'bold',
+                    cursor: props.onTitleTap ? 'pointer' : undefined
                 }}
+                onClick={props.onTitleTap}
             >
                 {props.children}
             </div>

--- a/app/src/views/Explorer.tsx
+++ b/app/src/views/Explorer.tsx
@@ -2,7 +2,7 @@ import { CommunityTimelineSchema, Schemas, semantics } from '@concrnt/worldlib'
 import { useClient } from '../contexts/Client'
 import { Text, View, Button, TextField } from '@concrnt/ui'
 import { Document } from '@concrnt/client'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { Header } from '../ui/Header'
 import { useDrawer } from '../contexts/Drawer'
 import { FAB } from '../ui/FAB'
@@ -15,6 +15,7 @@ export const ExplorerView = () => {
     const drawer = useDrawer()
 
     const [updater, setUpdater] = useState(0)
+    const scrollRef = useRef<HTMLDivElement>(null)
 
     const reload = () => {
         setUpdater((prev) => prev + 1)
@@ -23,8 +24,9 @@ export const ExplorerView = () => {
     return (
         <>
             <View>
-                <Header>Explorer</Header>
+                <Header onTitleTap={() => scrollRef.current?.scrollTo({ top: 0, behavior: 'smooth' })}>Explorer</Header>
                 <div
+                    ref={scrollRef}
                     style={{
                         flex: 1,
                         display: 'flex',

--- a/app/src/views/Home.tsx
+++ b/app/src/views/Home.tsx
@@ -1,5 +1,5 @@
-import { startTransition, Suspense, useEffect, useState } from 'react'
-import { ScrollViewProps, ScrollViewRef } from '../types/ScrollView'
+import { startTransition, Suspense, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { ScrollViewHandle, ScrollViewProps, ScrollViewRef } from '../types/ScrollView'
 
 import { useClient } from '../contexts/Client'
 import { useDrawer } from '../contexts/Drawer'
@@ -25,6 +25,11 @@ export const HomeView = (props: ScrollViewProps) => {
     const { client } = useClient()
     const drawer = useDrawer()
 
+    const scrollRef = useRef<ScrollViewHandle>(null)
+    useImperativeHandle(props.ref, () => ({
+        scrollToTop: () => scrollRef.current?.scrollToTop()
+    }))
+
     const [selectedTabUri, setSelectedTabUri] = useState<string>('')
 
     // fix default settings
@@ -46,6 +51,7 @@ export const HomeView = (props: ScrollViewProps) => {
         <>
             <View>
                 <Header
+                    onTitleTap={() => scrollRef.current?.scrollToTop()}
                     right={
                         <div
                             style={{
@@ -73,7 +79,7 @@ export const HomeView = (props: ScrollViewProps) => {
                     Home
                 </Header>
                 <Suspense>
-                    <HomeMain ref={props.ref} selectedTabUri={selectedTabUri} setSelectedTabUri={setSelectedTabUri} />
+                    <HomeMain ref={scrollRef} selectedTabUri={selectedTabUri} setSelectedTabUri={setSelectedTabUri} />
                 </Suspense>
             </View>
         </>

--- a/app/src/views/Notifications.tsx
+++ b/app/src/views/Notifications.tsx
@@ -1,13 +1,16 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { View } from '@concrnt/ui'
 import { Header } from '../ui/Header'
 import { NotificationTimeline } from '../components/NotificationTimeline'
 import { NotificationFilter } from '../components/NotificationFilter'
 import { useClient } from '../contexts/Client'
 import { semantics } from '@concrnt/worldlib'
+import { ScrollViewHandle } from '../types/ScrollView'
 
 export const NotificationsView = () => {
     const { client } = useClient()
+
+    const scrollRef = useRef<ScrollViewHandle>(null)
 
     const [selected, setSelected] = useState<string | undefined>(undefined)
 
@@ -28,9 +31,10 @@ export const NotificationsView = () => {
 
     return (
         <View>
-            <Header>Notifications</Header>
+            <Header onTitleTap={() => scrollRef.current?.scrollToTop()}>Notifications</Header>
             <NotificationFilter selected={selected} setSelected={setSelected} />
             <NotificationTimeline
+                ref={scrollRef}
                 prefix={semantics.notificationTimeline(client.ccid, client.currentProfile) + '/'}
                 query={query}
             />

--- a/app/src/views/Timeline.tsx
+++ b/app/src/views/Timeline.tsx
@@ -1,6 +1,6 @@
 import { View } from '@concrnt/ui'
 import { Header } from '../ui/Header'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { useClient } from '../contexts/Client'
 import { RealtimeTimeline } from '../components/RealtimeTimeline'
 import { FAB } from '../ui/FAB'
@@ -8,6 +8,7 @@ import { useComposer } from '../contexts/Composer'
 import { MdCreate } from 'react-icons/md'
 import { hapticLight } from '../utils/haptics'
 import { TimelineTag } from '../components/TimelineTag'
+import { ScrollViewHandle } from '../types/ScrollView'
 
 interface Props {
     uri: string
@@ -17,6 +18,8 @@ export const TimelineView = (props: Props) => {
     const { client } = useClient()
     const composer = useComposer()
 
+    const scrollRef = useRef<ScrollViewHandle>(null)
+
     const timelinePromise = useMemo(() => {
         return client!.getTimeline(props.uri).catch(() => null)
     }, [client, props.uri])
@@ -24,10 +27,10 @@ export const TimelineView = (props: Props) => {
     return (
         <>
             <View>
-                <Header>
+                <Header onTitleTap={() => scrollRef.current?.scrollToTop()}>
                     <TimelineTag uri={props.uri} />
                 </Header>
-                <RealtimeTimeline timelines={[props.uri]} />
+                <RealtimeTimeline ref={scrollRef} timelines={[props.uri]} />
             </View>
             <FAB
                 onClick={() => {

--- a/web/src/ui/Header.tsx
+++ b/web/src/ui/Header.tsx
@@ -7,6 +7,7 @@ interface Props {
     children?: ReactNode
     leftOverride?: ReactNode
     right?: ReactNode
+    onTitleTap?: () => void
 }
 
 export const Header = (props: Props) => {
@@ -39,8 +40,10 @@ export const Header = (props: Props) => {
                 style={{
                     flexGrow: 1,
                     textAlign: 'center',
-                    fontWeight: 'bold'
+                    fontWeight: 'bold',
+                    cursor: props.onTitleTap ? 'pointer' : undefined
                 }}
+                onClick={props.onTitleTap}
             >
                 {props.children}
             </div>

--- a/web/src/views/Explorer.tsx
+++ b/web/src/views/Explorer.tsx
@@ -2,7 +2,7 @@ import { CommunityTimelineSchema, Schemas, semantics } from '@concrnt/worldlib'
 import { useClient } from '../contexts/Client'
 import { Text, View, Button, TextField } from '@concrnt/ui'
 import { Document } from '@concrnt/client'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { Header } from '../ui/Header'
 import { useDrawer } from '../contexts/Drawer'
 import { MdAdd } from 'react-icons/md'
@@ -14,6 +14,7 @@ export const ExplorerView = () => {
     const drawer = useDrawer()
 
     const [updater, setUpdater] = useState(0)
+    const scrollRef = useRef<HTMLDivElement>(null)
 
     const reload = () => {
         setUpdater((prev) => prev + 1)
@@ -23,6 +24,7 @@ export const ExplorerView = () => {
         <>
             <View>
                 <Header
+                    onTitleTap={() => scrollRef.current?.scrollTo({ top: 0, behavior: 'smooth' })}
                     right={
                         <Button
                             variant="text"
@@ -44,6 +46,7 @@ export const ExplorerView = () => {
                     Explorer
                 </Header>
                 <div
+                    ref={scrollRef}
                     style={{
                         flex: 1,
                         display: 'flex',

--- a/web/src/views/Home.tsx
+++ b/web/src/views/Home.tsx
@@ -1,5 +1,5 @@
-import { startTransition, Suspense, useEffect, useState } from 'react'
-import { ScrollViewProps, ScrollViewRef } from '../types/ScrollView'
+import { startTransition, Suspense, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { ScrollViewHandle, ScrollViewProps, ScrollViewRef } from '../types/ScrollView'
 
 import { useClient } from '../contexts/Client'
 import { useDrawer } from '../contexts/Drawer'
@@ -20,6 +20,11 @@ import { useSubscribe } from '../hooks/useSubscribe'
 export const HomeView = (props: ScrollViewProps) => {
     const { client } = useClient()
     const drawer = useDrawer()
+
+    const scrollRef = useRef<ScrollViewHandle>(null)
+    useImperativeHandle(props.ref, () => ({
+        scrollToTop: () => scrollRef.current?.scrollToTop()
+    }))
 
     const [selectedTabUri, setSelectedTabUri] = useState<string>('')
 
@@ -50,6 +55,7 @@ export const HomeView = (props: ScrollViewProps) => {
         <>
             <View>
                 <Header
+                    onTitleTap={() => scrollRef.current?.scrollToTop()}
                     right={
                         <div
                             style={{
@@ -77,7 +83,7 @@ export const HomeView = (props: ScrollViewProps) => {
                     Home
                 </Header>
                 <Suspense>
-                    <HomeMain ref={props.ref} selectedTabUri={selectedTabUri} setSelectedTabUri={setSelectedTabUri} />
+                    <HomeMain ref={scrollRef} selectedTabUri={selectedTabUri} setSelectedTabUri={setSelectedTabUri} />
                 </Suspense>
             </View>
         </>

--- a/web/src/views/Notifications.tsx
+++ b/web/src/views/Notifications.tsx
@@ -1,13 +1,16 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { View } from '@concrnt/ui'
 import { Header } from '../ui/Header'
 import { NotificationTimeline } from '../components/NotificationTimeline'
 import { NotificationFilter } from '../components/NotificationFilter'
 import { useClient } from '../contexts/Client'
 import { semantics } from '@concrnt/worldlib'
+import { ScrollViewHandle } from '../types/ScrollView'
 
 export const NotificationsView = () => {
     const { client } = useClient()
+
+    const scrollRef = useRef<ScrollViewHandle>(null)
 
     const [selected, setSelected] = useState<string | undefined>(undefined)
 
@@ -28,9 +31,10 @@ export const NotificationsView = () => {
 
     return (
         <View>
-            <Header>Notifications</Header>
+            <Header onTitleTap={() => scrollRef.current?.scrollToTop()}>Notifications</Header>
             <NotificationFilter selected={selected} setSelected={setSelected} />
             <NotificationTimeline
+                ref={scrollRef}
                 prefix={semantics.notificationTimeline(client.ccid, client.currentProfile) + '/'}
                 query={query}
             />

--- a/web/src/views/Timeline.tsx
+++ b/web/src/views/Timeline.tsx
@@ -1,11 +1,12 @@
 import { Button, View } from '@concrnt/ui'
 import { Header } from '../ui/Header'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { useClient } from '../contexts/Client'
 import { RealtimeTimeline } from '../components/RealtimeTimeline'
 import { useComposer } from '../contexts/Composer'
 import { MdCreate } from 'react-icons/md'
 import { TimelineTag } from '../components/TimelineTag'
+import { ScrollViewHandle } from '../types/ScrollView'
 
 interface Props {
     uri: string
@@ -15,6 +16,8 @@ export const TimelineView = (props: Props) => {
     const { client } = useClient()
     const composer = useComposer()
 
+    const scrollRef = useRef<ScrollViewHandle>(null)
+
     const timelinePromise = useMemo(() => {
         return client!.getTimeline(props.uri).catch(() => null)
     }, [client, props.uri])
@@ -23,6 +26,7 @@ export const TimelineView = (props: Props) => {
         <>
             <View>
                 <Header
+                    onTitleTap={() => scrollRef.current?.scrollToTop()}
                     right={
                         <Button
                             variant="text"
@@ -39,7 +43,7 @@ export const TimelineView = (props: Props) => {
                 >
                     <TimelineTag uri={props.uri} />
                 </Header>
-                <RealtimeTimeline timelines={[props.uri]} />
+                <RealtimeTimeline ref={scrollRef} timelines={[props.uri]} />
             </View>
         </>
     )


### PR DESCRIPTION
resolve #78 

## 概要
ヘッダーのタイトル部分をタップすると、タイムラインが一番上にスムーズスクロールで戻る機能を追加しました。app版・web版の両方に対応しています。
 
## 変更内容
 
### Header コンポーネント
- `onTitleTap` プロパティを追加
- タイトル部分（中央エリア）に `onClick` ハンドラを設定
- `onTitleTap` が渡されている場合のみ `cursor: pointer` を適用
### 対応画面
| 画面 | スクロール対象 |
|---|---|
| Home | RealtimeTimeline（`useImperativeHandle` 経由） |
| Timeline | RealtimeTimeline（同上） |
| Notifications | NotificationTimeline（同上） |
| Explorer | overflow div（直接 `scrollTo`） |
 
### 変更ファイル（10ファイル）
- `app/src/ui/Header.tsx`
- `web/src/ui/Header.tsx`
- `app/src/views/Home.tsx`
- `web/src/views/Home.tsx`
- `app/src/views/Timeline.tsx`
- `web/src/views/Timeline.tsx`
- `app/src/views/Notifications.tsx`
- `web/src/views/Notifications.tsx`
- `app/src/views/Explorer.tsx`
- `web/src/views/Explorer.tsx`
## 設計メモ
- `RealtimeTimeline` / `NotificationTimeline` は既に `useImperativeHandle` で `scrollToTop()` を公開しているため、各ビューからは `ref` を渡して呼ぶだけで済んでいます
- `HomeView` は `MainView` からのタブ再タップ→`scrollToTop` にも対応しており、ローカル `ref` を作成した上で `useImperativeHandle` で `props.ref` へ転送することで既存の動作を維持しています
- `Explorer` はタイムラインコンポーネントではなく `overflowY: auto` の div なので、直接 `scrollTo` を呼んでいます
## 対象外
- **Contacts**: `AcknowledgeList` が内部でスクロールコンテナを管理しており、外から `ref` を取れない構造のため
- **Profile**: `Header` コンポーネントを使わず `CCWallpaper` が独自ヘッダーとなっているため


これらは必要に応じて別 Issue です。