### PR TITLE
Explorer 画面で検索機能を実装しました。

### DIFF
--- a/app/src/components/SearchExplorer.tsx
+++ b/app/src/components/SearchExplorer.tsx
@@ -1,0 +1,329 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { Text, TextField, CCWallpaper, Avatar, IconButton, Tab, Tabs, useTheme } from '@concrnt/ui'
+import { CssVar } from '../types/Theme'
+import { useDrawer } from '../contexts/Drawer'
+import { Subscription } from './Subscription'
+import { MdPlaylistAdd, MdCasino } from 'react-icons/md'
+import { useStack } from '../layouts/Stack'
+import { TimelineView } from '../views/Timeline'
+import { ProfileView } from '../views/Profile'
+
+// Crawler API base URL
+// https://github.com/concrnt/crawler
+const CRAWLER_URL = 'https://crawler.concrnt.net'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface CommunityHit {
+    id: string // Meilisearch内部ID (base64)
+    cckv: string // タイムラインURI (例: cckv://domain/t/key)
+    name: string
+    description?: string
+    banner?: string
+    owner?: string
+    sourceServer?: string
+}
+
+export interface UserHit {
+    id: string // Meilisearch内部ID (base64)
+    ccid: string // ユーザーCCID
+    username?: string
+    description?: string
+    avatar?: string
+    banner?: string
+    owner?: string
+    sourceServer?: string
+}
+
+interface SearchResponse<T> {
+    hits: T[]
+    query: string
+    limit: number
+    offset: number
+    estimatedTotalHits: number
+    processingTimeMs: number
+}
+
+type TabType = 'communities' | 'users'
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export const SearchExplorer = () => {
+    const theme = useTheme()
+    const activeColor = theme.variant === 'classic' ? CssVar.backdropBackground : CssVar.contentLink
+    const inactiveColor = `rgb(from ${CssVar.contentText} r g b / 0.35)`
+    const tabStyle = (selected: boolean) => ({
+        color: selected ? activeColor : inactiveColor,
+        fontWeight: selected ? ('bold' as const) : ('normal' as const)
+    })
+
+    const [tab, setTab] = useState<TabType>('communities')
+    const [query, setQuery] = useState('')
+    const [communities, setCommunities] = useState<CommunityHit[]>([])
+    const [users, setUsers] = useState<UserHit[]>([])
+    const [loading, setLoading] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const [shuffleSeed, setShuffleSeed] = useState(0)
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    const fetchData = useCallback(async (currentTab: TabType, currentQuery: string) => {
+        setLoading(true)
+        setError(null)
+        try {
+            const q = encodeURIComponent(currentQuery)
+            if (currentTab === 'communities') {
+                const res = await fetch(`${CRAWLER_URL}/api/v1/search/communities?q=${q}&limit=20`)
+                if (!res.ok) throw new Error(`HTTP ${res.status}`)
+                const data: SearchResponse<CommunityHit> = await res.json()
+                setCommunities(currentQuery === '' ? shuffleArray(data.hits) : data.hits)
+            } else {
+                const res = await fetch(`${CRAWLER_URL}/api/v1/search/users?q=${q}&limit=20`)
+                if (!res.ok) throw new Error(`HTTP ${res.status}`)
+                const data: SearchResponse<UserHit> = await res.json()
+                setUsers(currentQuery === '' ? shuffleArray(data.hits) : data.hits)
+            }
+        } catch {
+            setError('検索サービスに接続できませんでした')
+        } finally {
+            setLoading(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        if (debounceRef.current) clearTimeout(debounceRef.current)
+        debounceRef.current = setTimeout(() => {
+            fetchData(tab, query)
+        }, 300)
+        return () => {
+            if (debounceRef.current) clearTimeout(debounceRef.current)
+        }
+    }, [query, tab, shuffleSeed, fetchData])
+
+    const handleShuffle = () => {
+        setShuffleSeed((s) => s + 1)
+    }
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: CssVar.space(2) }}>
+            <Tabs>
+                <Tab
+                    selected={tab === 'communities'}
+                    groupId="search-explorer"
+                    style={tabStyle(tab === 'communities')}
+                    onClick={() => setTab('communities')}
+                >
+                    <Text>コミュニティ</Text>
+                </Tab>
+                <Tab
+                    selected={tab === 'users'}
+                    groupId="search-explorer"
+                    style={tabStyle(tab === 'users')}
+                    onClick={() => setTab('users')}
+                >
+                    <Text>ユーザー</Text>
+                </Tab>
+            </Tabs>
+
+            <TextField
+                value={query}
+                placeholder={tab === 'communities' ? 'コミュニティを検索...' : 'ユーザーを検索...'}
+                onChange={(e) => setQuery(e.target.value)}
+            />
+
+            {error && (
+                <Text variant="caption" style={{ color: 'var(--error, #f44336)' }}>
+                    {error}
+                </Text>
+            )}
+
+            {loading ? (
+                <Text variant="caption">読み込み中...</Text>
+            ) : tab === 'communities' ? (
+                communities.length === 0 ? (
+                    <Text variant="caption" style={{ opacity: 0.5 }}>
+                        {query ? '該当するコミュニティが見つかりませんでした' : '読み込み中...'}
+                    </Text>
+                ) : (
+                    <CommunityResultList communities={communities} />
+                )
+            ) : users.length === 0 ? (
+                <Text variant="caption" style={{ opacity: 0.5 }}>
+                    {query ? '該当するユーザーが見つかりませんでした' : '読み込み中...'}
+                </Text>
+            ) : (
+                <UserResultList users={users} />
+            )}
+
+            {/* シャッフルボタン（空クエリ時のみ表示） */}
+            {!query && !loading && (
+                <div style={{ display: 'flex', justifyContent: 'center', marginTop: CssVar.space(2) }}>
+                    <button
+                        onClick={handleShuffle}
+                        style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: CssVar.space(1),
+                            padding: `${CssVar.space(2)} ${CssVar.space(4)}`,
+                            borderRadius: CssVar.round(2),
+                            border: `1px solid ${CssVar.divider}`,
+                            backgroundColor: 'transparent',
+                            color: CssVar.contentText,
+                            cursor: 'pointer',
+                            fontSize: '0.9rem'
+                        }}
+                    >
+                        <MdCasino size={18} />
+                        シャッフル
+                    </button>
+                </div>
+            )}
+        </div>
+    )
+}
+
+// ─── Community list ───────────────────────────────────────────────────────────
+
+const CommunityResultList = ({ communities }: { communities: CommunityHit[] }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: CssVar.space(2) }}>
+        {communities.map((c) => (
+            <CommunityResultCard key={c.id} community={c} />
+        ))}
+    </div>
+)
+
+const CommunityResultCard = ({ community }: { community: CommunityHit }) => {
+    const drawer = useDrawer()
+    const { push } = useStack()
+
+    return (
+        <div
+            style={{
+                border: `1px solid ${CssVar.divider}`,
+                borderRadius: '8px',
+                display: 'flex',
+                overflow: 'hidden',
+                height: '7rem',
+                minHeight: '7rem',
+                cursor: 'pointer'
+            }}
+        >
+            <CCWallpaper style={{ height: '100%', aspectRatio: '1/1', flexShrink: 0 }} src={community.banner} />
+            <div
+                style={{
+                    padding: '8px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    flexGrow: 1,
+                    minWidth: 0
+                }}
+                onClick={() => push(<TimelineView uri={community.cckv} />)}
+            >
+                <Text variant="h4" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {community.name}
+                </Text>
+                <Text
+                    style={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        opacity: 0.7
+                    }}
+                >
+                    {community.description}
+                </Text>
+                {community.sourceServer && (
+                    <Text
+                        variant="caption"
+                        style={{ opacity: 0.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    >
+                        {community.sourceServer}
+                    </Text>
+                )}
+                <div style={{ marginTop: 'auto', display: 'flex', justifyContent: 'flex-end' }}>
+                    <IconButton
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            drawer.open(<Subscription target={community.cckv} />)
+                        }}
+                    >
+                        <MdPlaylistAdd size={24} />
+                    </IconButton>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+// ─── User list ────────────────────────────────────────────────────────────────
+
+const UserResultList = ({ users }: { users: UserHit[] }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: CssVar.space(2) }}>
+        {users.map((u) => (
+            <UserResultCard key={u.id} user={u} />
+        ))}
+    </div>
+)
+
+const UserResultCard = ({ user }: { user: UserHit }) => {
+    const { push } = useStack()
+    const ccid = user.ccid
+
+    return (
+        <div
+            style={{
+                border: `1px solid ${CssVar.divider}`,
+                borderRadius: '8px',
+                overflow: 'hidden',
+                cursor: 'pointer'
+            }}
+            onClick={() => push(<ProfileView ccid={ccid} />)}
+        >
+            <CCWallpaper style={{ height: '60px', width: '100%' }} src={user.banner} />
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: CssVar.space(2),
+                    padding: CssVar.space(2)
+                }}
+            >
+                <Avatar
+                    ccid={ccid}
+                    src={user.avatar}
+                    style={{ width: '48px', height: '48px', borderRadius: '4px', flexShrink: 0 }}
+                />
+                <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0, flexGrow: 1 }}>
+                    <Text variant="h4" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {user.username ?? 'Anonymous'}
+                    </Text>
+                    <Text
+                        style={{
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            opacity: 0.7
+                        }}
+                    >
+                        {user.description}
+                    </Text>
+                    {user.sourceServer && (
+                        <Text variant="caption" style={{ opacity: 0.5 }}>
+                            {user.sourceServer}
+                        </Text>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+// ─── Util ─────────────────────────────────────────────────────────────────────
+
+function shuffleArray<T>(arr: T[]): T[] {
+    const a = [...arr]
+    for (let i = a.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[a[i], a[j]] = [a[j], a[i]]
+    }
+    return a
+}

--- a/app/src/components/SearchExplorer.tsx
+++ b/app/src/components/SearchExplorer.tsx
@@ -3,7 +3,7 @@ import { Text, TextField, CCWallpaper, Avatar, IconButton, Tab, Tabs, useTheme }
 import { CssVar } from '../types/Theme'
 import { useDrawer } from '../contexts/Drawer'
 import { Subscription } from './Subscription'
-import { MdPlaylistAdd, MdCasino } from 'react-icons/md'
+import { MdPlaylistAdd } from 'react-icons/md'
 import { useStack } from '../layouts/Stack'
 import { TimelineView } from '../views/Timeline'
 import { ProfileView } from '../views/Profile'
@@ -63,7 +63,6 @@ export const SearchExplorer = () => {
     const [users, setUsers] = useState<UserHit[]>([])
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState<string | null>(null)
-    const [shuffleSeed, setShuffleSeed] = useState(0)
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
     const fetchData = useCallback(async (currentTab: TabType, currentQuery: string) => {
@@ -75,12 +74,12 @@ export const SearchExplorer = () => {
                 const res = await fetch(`${CRAWLER_URL}/api/v1/search/communities?q=${q}&limit=20`)
                 if (!res.ok) throw new Error(`HTTP ${res.status}`)
                 const data: SearchResponse<CommunityHit> = await res.json()
-                setCommunities(currentQuery === '' ? shuffleArray(data.hits) : data.hits)
+                setCommunities(data.hits)
             } else {
                 const res = await fetch(`${CRAWLER_URL}/api/v1/search/users?q=${q}&limit=20`)
                 if (!res.ok) throw new Error(`HTTP ${res.status}`)
                 const data: SearchResponse<UserHit> = await res.json()
-                setUsers(currentQuery === '' ? shuffleArray(data.hits) : data.hits)
+                setUsers(data.hits)
             }
         } catch {
             setError('検索サービスに接続できませんでした')
@@ -97,11 +96,7 @@ export const SearchExplorer = () => {
         return () => {
             if (debounceRef.current) clearTimeout(debounceRef.current)
         }
-    }, [query, tab, shuffleSeed, fetchData])
-
-    const handleShuffle = () => {
-        setShuffleSeed((s) => s + 1)
-    }
+    }, [query, tab, fetchData])
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column', gap: CssVar.space(2) }}>
@@ -153,30 +148,6 @@ export const SearchExplorer = () => {
             ) : (
                 <UserResultList users={users} />
             )}
-
-            {/* シャッフルボタン（空クエリ時のみ表示） */}
-            {!query && !loading && (
-                <div style={{ display: 'flex', justifyContent: 'center', marginTop: CssVar.space(2) }}>
-                    <button
-                        onClick={handleShuffle}
-                        style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: CssVar.space(1),
-                            padding: `${CssVar.space(2)} ${CssVar.space(4)}`,
-                            borderRadius: CssVar.round(2),
-                            border: `1px solid ${CssVar.divider}`,
-                            backgroundColor: 'transparent',
-                            color: CssVar.contentText,
-                            cursor: 'pointer',
-                            fontSize: '0.9rem'
-                        }}
-                    >
-                        <MdCasino size={18} />
-                        シャッフル
-                    </button>
-                </div>
-            )}
         </div>
     )
 }
@@ -221,14 +192,7 @@ const CommunityResultCard = ({ community }: { community: CommunityHit }) => {
                 <Text variant="h4" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                     {community.name}
                 </Text>
-                <Text
-                    style={{
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        opacity: 0.7
-                    }}
-                >
+                <Text style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', opacity: 0.7 }}>
                     {community.description}
                 </Text>
                 {community.sourceServer && (
@@ -296,14 +260,7 @@ const UserResultCard = ({ user }: { user: UserHit }) => {
                     <Text variant="h4" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {user.username ?? 'Anonymous'}
                     </Text>
-                    <Text
-                        style={{
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                            opacity: 0.7
-                        }}
-                    >
+                    <Text style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', opacity: 0.7 }}>
                         {user.description}
                     </Text>
                     {user.sourceServer && (
@@ -315,15 +272,4 @@ const UserResultCard = ({ user }: { user: UserHit }) => {
             </div>
         </div>
     )
-}
-
-// ─── Util ─────────────────────────────────────────────────────────────────────
-
-function shuffleArray<T>(arr: T[]): T[] {
-    const a = [...arr]
-    for (let i = a.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1))
-        ;[a[i], a[j]] = [a[j], a[i]]
-    }
-    return a
 }

--- a/app/src/views/Explorer.tsx
+++ b/app/src/views/Explorer.tsx
@@ -27,6 +27,7 @@ export const ExplorerView = () => {
                         flexDirection: 'column',
                         gap: CssVar.space(2),
                         padding: CssVar.space(2),
+                        paddingBottom: '7rem',
                         overflowY: 'auto'
                     }}
                 >

--- a/app/src/views/Explorer.tsx
+++ b/app/src/views/Explorer.tsx
@@ -8,18 +8,12 @@ import { useDrawer } from '../contexts/Drawer'
 import { FAB } from '../ui/FAB'
 import { MdAdd } from 'react-icons/md'
 import { hapticLight, hapticSuccess } from '../utils/haptics'
-import { ClassicExplorer } from '../components/ClassicExplorer'
+import { SearchExplorer } from '../components/SearchExplorer'
 import { CssVar } from '../types/Theme'
 
 export const ExplorerView = () => {
     const drawer = useDrawer()
-
-    const [updater, setUpdater] = useState(0)
     const scrollRef = useRef<HTMLDivElement>(null)
-
-    const reload = () => {
-        setUpdater((prev) => prev + 1)
-    }
 
     return (
         <>
@@ -36,7 +30,7 @@ export const ExplorerView = () => {
                         overflowY: 'auto'
                     }}
                 >
-                    <ClassicExplorer updater={updater} />
+                    <SearchExplorer />
                 </div>
             </View>
             <FAB
@@ -46,7 +40,6 @@ export const ExplorerView = () => {
                         <CommunityCreator
                             onComplete={() => {
                                 drawer.close()
-                                reload()
                             }}
                         />
                     )
@@ -60,16 +53,12 @@ export const ExplorerView = () => {
 
 const CommunityCreator = ({ onComplete }: { onComplete: () => void }) => {
     const [communityName, setCommunityName] = useState('')
-
     const [communityDescription, setCommunityDescription] = useState('')
-
     const { client } = useClient()
 
     const createCommunity = async (value: CommunityTimelineSchema) => {
         if (!client) return
-
         const key = Date.now().toString()
-
         const document: Document<CommunityTimelineSchema> = {
             key: semantics.community(client.server.domain, key),
             schema: Schemas.communityTimeline,
@@ -84,7 +73,6 @@ const CommunityCreator = ({ onComplete }: { onComplete: () => void }) => {
                 ]
             }
         }
-
         await client.api.commit(document)
         console.log('Community created')
     }

--- a/web/src/components/SearchExplorer.tsx
+++ b/web/src/components/SearchExplorer.tsx
@@ -1,0 +1,327 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { Text, TextField, CCWallpaper, Avatar, IconButton, Tab, Tabs, useTheme } from '@concrnt/ui'
+import { CssVar } from '../types/Theme'
+import { useDrawer } from '../contexts/Drawer'
+import { Subscription } from './Subscription'
+import { MdPlaylistAdd, MdCasino } from 'react-icons/md'
+import { useNavigate } from 'react-router-dom'
+
+// Crawler API base URL
+// https://github.com/concrnt/crawler
+const CRAWLER_URL = 'https://crawler.concrnt.net'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface CommunityHit {
+    id: string // Meilisearch内部ID (base64)
+    cckv: string // タイムラインURI (例: cckv://domain/t/key)
+    name: string
+    description?: string
+    banner?: string
+    owner?: string
+    sourceServer?: string
+}
+
+export interface UserHit {
+    id: string // Meilisearch内部ID (base64)
+    ccid: string // ユーザーCCID
+    username?: string
+    description?: string
+    avatar?: string
+    banner?: string
+    owner?: string
+    sourceServer?: string
+}
+
+interface SearchResponse<T> {
+    hits: T[]
+    query: string
+    limit: number
+    offset: number
+    estimatedTotalHits: number
+    processingTimeMs: number
+}
+
+type TabType = 'communities' | 'users'
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export const SearchExplorer = () => {
+    const theme = useTheme()
+    const activeColor = theme.variant === 'classic' ? CssVar.backdropBackground : CssVar.contentLink
+    const inactiveColor = `rgb(from ${CssVar.contentText} r g b / 0.35)`
+    const tabStyle = (selected: boolean) => ({
+        color: selected ? activeColor : inactiveColor,
+        fontWeight: selected ? ('bold' as const) : ('normal' as const)
+    })
+
+    const [tab, setTab] = useState<TabType>('communities')
+    const [query, setQuery] = useState('')
+    const [communities, setCommunities] = useState<CommunityHit[]>([])
+    const [users, setUsers] = useState<UserHit[]>([])
+    const [loading, setLoading] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const [shuffleSeed, setShuffleSeed] = useState(0)
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    const fetchData = useCallback(async (currentTab: TabType, currentQuery: string) => {
+        setLoading(true)
+        setError(null)
+        try {
+            const q = encodeURIComponent(currentQuery)
+            if (currentTab === 'communities') {
+                const res = await fetch(`${CRAWLER_URL}/api/v1/search/communities?q=${q}&limit=20`)
+                if (!res.ok) throw new Error(`HTTP ${res.status}`)
+                const data: SearchResponse<CommunityHit> = await res.json()
+                setCommunities(currentQuery === '' ? shuffleArray(data.hits) : data.hits)
+            } else {
+                const res = await fetch(`${CRAWLER_URL}/api/v1/search/users?q=${q}&limit=20`)
+                if (!res.ok) throw new Error(`HTTP ${res.status}`)
+                const data: SearchResponse<UserHit> = await res.json()
+                setUsers(currentQuery === '' ? shuffleArray(data.hits) : data.hits)
+            }
+        } catch {
+            setError('検索サービスに接続できませんでした')
+        } finally {
+            setLoading(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        if (debounceRef.current) clearTimeout(debounceRef.current)
+        debounceRef.current = setTimeout(() => {
+            fetchData(tab, query)
+        }, 300)
+        return () => {
+            if (debounceRef.current) clearTimeout(debounceRef.current)
+        }
+    }, [query, tab, shuffleSeed, fetchData])
+
+    const handleShuffle = () => {
+        setShuffleSeed((s) => s + 1)
+    }
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: CssVar.space(2) }}>
+            <Tabs>
+                <Tab
+                    selected={tab === 'communities'}
+                    groupId="search-explorer"
+                    style={tabStyle(tab === 'communities')}
+                    onClick={() => setTab('communities')}
+                >
+                    <Text>コミュニティ</Text>
+                </Tab>
+                <Tab
+                    selected={tab === 'users'}
+                    groupId="search-explorer"
+                    style={tabStyle(tab === 'users')}
+                    onClick={() => setTab('users')}
+                >
+                    <Text>ユーザー</Text>
+                </Tab>
+            </Tabs>
+
+            <TextField
+                value={query}
+                placeholder={tab === 'communities' ? 'コミュニティを検索...' : 'ユーザーを検索...'}
+                onChange={(e) => setQuery(e.target.value)}
+            />
+
+            {error && (
+                <Text variant="caption" style={{ color: 'var(--error, #f44336)' }}>
+                    {error}
+                </Text>
+            )}
+
+            {loading ? (
+                <Text variant="caption">読み込み中...</Text>
+            ) : tab === 'communities' ? (
+                communities.length === 0 ? (
+                    <Text variant="caption" style={{ opacity: 0.5 }}>
+                        {query ? '該当するコミュニティが見つかりませんでした' : '読み込み中...'}
+                    </Text>
+                ) : (
+                    <CommunityResultList communities={communities} />
+                )
+            ) : users.length === 0 ? (
+                <Text variant="caption" style={{ opacity: 0.5 }}>
+                    {query ? '該当するユーザーが見つかりませんでした' : '読み込み中...'}
+                </Text>
+            ) : (
+                <UserResultList users={users} />
+            )}
+
+            {/* シャッフルボタン（空クエリ時のみ表示） */}
+            {!query && !loading && (
+                <div style={{ display: 'flex', justifyContent: 'center', marginTop: CssVar.space(2) }}>
+                    <button
+                        onClick={handleShuffle}
+                        style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: CssVar.space(1),
+                            padding: `${CssVar.space(2)} ${CssVar.space(4)}`,
+                            borderRadius: CssVar.round(2),
+                            border: `1px solid ${CssVar.divider}`,
+                            backgroundColor: 'transparent',
+                            color: CssVar.contentText,
+                            cursor: 'pointer',
+                            fontSize: '0.9rem'
+                        }}
+                    >
+                        <MdCasino size={18} />
+                        シャッフル
+                    </button>
+                </div>
+            )}
+        </div>
+    )
+}
+
+// ─── Community list ───────────────────────────────────────────────────────────
+
+const CommunityResultList = ({ communities }: { communities: CommunityHit[] }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: CssVar.space(2) }}>
+        {communities.map((c) => (
+            <CommunityResultCard key={c.id} community={c} />
+        ))}
+    </div>
+)
+
+const CommunityResultCard = ({ community }: { community: CommunityHit }) => {
+    const drawer = useDrawer()
+    const navigate = useNavigate()
+
+    return (
+        <div
+            style={{
+                border: `1px solid ${CssVar.divider}`,
+                borderRadius: '8px',
+                display: 'flex',
+                overflow: 'hidden',
+                height: '7rem',
+                minHeight: '7rem',
+                cursor: 'pointer'
+            }}
+        >
+            <CCWallpaper style={{ height: '100%', aspectRatio: '1/1', flexShrink: 0 }} src={community.banner} />
+            <div
+                style={{
+                    padding: '8px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    flexGrow: 1,
+                    minWidth: 0
+                }}
+                onClick={() => navigate('/timeline/' + encodeURIComponent(community.cckv))}
+            >
+                <Text variant="h4" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {community.name}
+                </Text>
+                <Text
+                    style={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        opacity: 0.7
+                    }}
+                >
+                    {community.description}
+                </Text>
+                {community.sourceServer && (
+                    <Text
+                        variant="caption"
+                        style={{ opacity: 0.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    >
+                        {community.sourceServer}
+                    </Text>
+                )}
+                <div style={{ marginTop: 'auto', display: 'flex', justifyContent: 'flex-end' }}>
+                    <IconButton
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            drawer.open(<Subscription target={community.cckv} />)
+                        }}
+                    >
+                        <MdPlaylistAdd size={24} />
+                    </IconButton>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+// ─── User list ────────────────────────────────────────────────────────────────
+
+const UserResultList = ({ users }: { users: UserHit[] }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: CssVar.space(2) }}>
+        {users.map((u) => (
+            <UserResultCard key={u.id} user={u} />
+        ))}
+    </div>
+)
+
+const UserResultCard = ({ user }: { user: UserHit }) => {
+    const navigate = useNavigate()
+    const ccid = user.ccid
+
+    return (
+        <div
+            style={{
+                border: `1px solid ${CssVar.divider}`,
+                borderRadius: '8px',
+                overflow: 'hidden',
+                cursor: 'pointer'
+            }}
+            onClick={() => navigate('/profile/' + encodeURIComponent(ccid))}
+        >
+            <CCWallpaper style={{ height: '60px', width: '100%' }} src={user.banner} />
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: CssVar.space(2),
+                    padding: CssVar.space(2)
+                }}
+            >
+                <Avatar
+                    ccid={ccid}
+                    src={user.avatar}
+                    style={{ width: '48px', height: '48px', borderRadius: '4px', flexShrink: 0 }}
+                />
+                <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0, flexGrow: 1 }}>
+                    <Text variant="h4" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {user.username ?? 'Anonymous'}
+                    </Text>
+                    <Text
+                        style={{
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            opacity: 0.7
+                        }}
+                    >
+                        {user.description}
+                    </Text>
+                    {user.sourceServer && (
+                        <Text variant="caption" style={{ opacity: 0.5 }}>
+                            {user.sourceServer}
+                        </Text>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+// ─── Util ─────────────────────────────────────────────────────────────────────
+
+function shuffleArray<T>(arr: T[]): T[] {
+    const a = [...arr]
+    for (let i = a.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[a[i], a[j]] = [a[j], a[i]]
+    }
+    return a
+}

--- a/web/src/components/SearchExplorer.tsx
+++ b/web/src/components/SearchExplorer.tsx
@@ -3,7 +3,7 @@ import { Text, TextField, CCWallpaper, Avatar, IconButton, Tab, Tabs, useTheme }
 import { CssVar } from '../types/Theme'
 import { useDrawer } from '../contexts/Drawer'
 import { Subscription } from './Subscription'
-import { MdPlaylistAdd, MdCasino } from 'react-icons/md'
+import { MdPlaylistAdd } from 'react-icons/md'
 import { useNavigate } from 'react-router-dom'
 
 // Crawler API base URL
@@ -61,7 +61,6 @@ export const SearchExplorer = () => {
     const [users, setUsers] = useState<UserHit[]>([])
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState<string | null>(null)
-    const [shuffleSeed, setShuffleSeed] = useState(0)
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
     const fetchData = useCallback(async (currentTab: TabType, currentQuery: string) => {
@@ -73,12 +72,12 @@ export const SearchExplorer = () => {
                 const res = await fetch(`${CRAWLER_URL}/api/v1/search/communities?q=${q}&limit=20`)
                 if (!res.ok) throw new Error(`HTTP ${res.status}`)
                 const data: SearchResponse<CommunityHit> = await res.json()
-                setCommunities(currentQuery === '' ? shuffleArray(data.hits) : data.hits)
+                setCommunities(data.hits)
             } else {
                 const res = await fetch(`${CRAWLER_URL}/api/v1/search/users?q=${q}&limit=20`)
                 if (!res.ok) throw new Error(`HTTP ${res.status}`)
                 const data: SearchResponse<UserHit> = await res.json()
-                setUsers(currentQuery === '' ? shuffleArray(data.hits) : data.hits)
+                setUsers(data.hits)
             }
         } catch {
             setError('検索サービスに接続できませんでした')
@@ -95,11 +94,7 @@ export const SearchExplorer = () => {
         return () => {
             if (debounceRef.current) clearTimeout(debounceRef.current)
         }
-    }, [query, tab, shuffleSeed, fetchData])
-
-    const handleShuffle = () => {
-        setShuffleSeed((s) => s + 1)
-    }
+    }, [query, tab, fetchData])
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column', gap: CssVar.space(2) }}>
@@ -151,30 +146,6 @@ export const SearchExplorer = () => {
             ) : (
                 <UserResultList users={users} />
             )}
-
-            {/* シャッフルボタン（空クエリ時のみ表示） */}
-            {!query && !loading && (
-                <div style={{ display: 'flex', justifyContent: 'center', marginTop: CssVar.space(2) }}>
-                    <button
-                        onClick={handleShuffle}
-                        style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: CssVar.space(1),
-                            padding: `${CssVar.space(2)} ${CssVar.space(4)}`,
-                            borderRadius: CssVar.round(2),
-                            border: `1px solid ${CssVar.divider}`,
-                            backgroundColor: 'transparent',
-                            color: CssVar.contentText,
-                            cursor: 'pointer',
-                            fontSize: '0.9rem'
-                        }}
-                    >
-                        <MdCasino size={18} />
-                        シャッフル
-                    </button>
-                </div>
-            )}
         </div>
     )
 }
@@ -219,14 +190,7 @@ const CommunityResultCard = ({ community }: { community: CommunityHit }) => {
                 <Text variant="h4" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                     {community.name}
                 </Text>
-                <Text
-                    style={{
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        opacity: 0.7
-                    }}
-                >
+                <Text style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', opacity: 0.7 }}>
                     {community.description}
                 </Text>
                 {community.sourceServer && (
@@ -294,14 +258,7 @@ const UserResultCard = ({ user }: { user: UserHit }) => {
                     <Text variant="h4" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {user.username ?? 'Anonymous'}
                     </Text>
-                    <Text
-                        style={{
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                            opacity: 0.7
-                        }}
-                    >
+                    <Text style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', opacity: 0.7 }}>
                         {user.description}
                     </Text>
                     {user.sourceServer && (
@@ -313,15 +270,4 @@ const UserResultCard = ({ user }: { user: UserHit }) => {
             </div>
         </div>
     )
-}
-
-// ─── Util ─────────────────────────────────────────────────────────────────────
-
-function shuffleArray<T>(arr: T[]): T[] {
-    const a = [...arr]
-    for (let i = a.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1))
-        ;[a[i], a[j]] = [a[j], a[i]]
-    }
-    return a
 }

--- a/web/src/views/Explorer.tsx
+++ b/web/src/views/Explorer.tsx
@@ -7,18 +7,12 @@ import { Header } from '../ui/Header'
 import { useDrawer } from '../contexts/Drawer'
 import { MdAdd } from 'react-icons/md'
 import { hapticSuccess } from '../utils/haptics'
-import { ClassicExplorer } from '../components/ClassicExplorer'
+import { SearchExplorer } from '../components/SearchExplorer'
 import { CssVar } from '../types/Theme'
 
 export const ExplorerView = () => {
     const drawer = useDrawer()
-
-    const [updater, setUpdater] = useState(0)
     const scrollRef = useRef<HTMLDivElement>(null)
-
-    const reload = () => {
-        setUpdater((prev) => prev + 1)
-    }
 
     return (
         <>
@@ -33,7 +27,6 @@ export const ExplorerView = () => {
                                     <CommunityCreator
                                         onComplete={() => {
                                             drawer.close()
-                                            reload()
                                         }}
                                     />
                                 )
@@ -56,7 +49,7 @@ export const ExplorerView = () => {
                         overflowY: 'auto'
                     }}
                 >
-                    <ClassicExplorer updater={updater} />
+                    <SearchExplorer />
                 </div>
             </View>
         </>
@@ -65,16 +58,12 @@ export const ExplorerView = () => {
 
 const CommunityCreator = ({ onComplete }: { onComplete: () => void }) => {
     const [communityName, setCommunityName] = useState('')
-
     const [communityDescription, setCommunityDescription] = useState('')
-
     const { client } = useClient()
 
     const createCommunity = async (value: CommunityTimelineSchema) => {
         if (!client) return
-
         const key = Date.now().toString()
-
         const document: Document<CommunityTimelineSchema> = {
             key: semantics.community(client.server.domain, key),
             schema: Schemas.communityTimeline,
@@ -89,7 +78,6 @@ const CommunityCreator = ({ onComplete }: { onComplete: () => void }) => {
                 ]
             }
         }
-
         await client.api.commit(document)
         console.log('Community created')
     }


### PR DESCRIPTION
resolve #88 

`concrnt/crawler` サービスを使った新しい Explorer 画面を実装しました。
app 版・web 版の両方に対応しています。

## 変更内容

### 新規ファイル
- `app/src/components/SearchExplorer.tsx`
- `web/src/components/SearchExplorer.tsx`

### 更新ファイル
- `app/src/views/Explorer.tsx`
- `web/src/views/Explorer.tsx`

## 機能

- **コミュニティ / ユーザー タブ** で切り替え
- **検索ボックス**（300ms デバウンス）
- `https://crawler.concrnt.net` の `/api/v1/search/communities` および `/api/v1/search/users` を呼び出し
- コミュニティカード: バナー・名前・説明・sourceServer・リスト追加ボタン
- ユーザーカード: バナー・アバター・ユーザー名・説明・sourceServer
- カードタップでそれぞれ `TimelineView` / `ProfileView` へ遷移
- app 版: スクロールコンテナに `paddingBottom: 7rem` を追加し、FAB とカードの重なりを解消