### PR TITLE
画像のサムネイルサイズを調整するようにしました。

### DIFF
--- a/app/src/components/BlurhashImage.tsx
+++ b/app/src/components/BlurhashImage.tsx
@@ -40,7 +40,7 @@ export const BlurhashImage = (props: BlurhashImageProps) => {
     }
 
     return (
-        <div style={{ position: 'relative', overflow: 'hidden', lineHeight: 0 }}>
+        <div style={{ position: 'relative', overflow: 'hidden', lineHeight: 0, width: '100%', height: '100%' }}>
             <canvas
                 ref={canvasRef}
                 width={BLURHASH_WIDTH}

--- a/web/src/components/BlurhashImage.tsx
+++ b/web/src/components/BlurhashImage.tsx
@@ -40,7 +40,7 @@ export const BlurhashImage = (props: BlurhashImageProps) => {
     }
 
     return (
-        <div style={{ position: 'relative', overflow: 'hidden', lineHeight: 0 }}>
+        <div style={{ position: 'relative', overflow: 'hidden', lineHeight: 0, width: '100%', height: '100%' }}>
             <canvas
                 ref={canvasRef}
                 width={BLURHASH_WIDTH}


### PR DESCRIPTION
resolve #93 

BlurhashImage コンポーネントのラッパー div が親コンテナのサイズを埋めきれず、サムネイル画像に角丸が正しく適用されない問題を修正しました。

**問題**
MediaMessage の画像コンテナには borderRadius: '8px' + overflow: 'hidden' が設定されていますが、BlurhashImage（blurhash ありの場合）が返すラッパー div に明示的なサイズ指定がありませんでした。そのため画像が一定サイズに達しない場合、コンテナ端と画像の間に余白が生じ、角丸が視覚的に適用されていないように見えていました。

**変更内容**
BlurhashImage のラッパー div に width: '100%', height: '100%' を追加し、親コンテナを確実に埋めるように修正しました。

**変更ファイル**
app/src/components/BlurhashImage.tsx
web/src/components/BlurhashImage.tsx