### PR TITLE
リストの並べ替え機能を実装しました

### DIFF
--- a/app/src/contexts/Preference.tsx
+++ b/app/src/contexts/Preference.tsx
@@ -6,11 +6,14 @@ import { semantics } from '@concrnt/worldlib'
 export interface Preference {
     themeName: string
     themeVariant: 'classic' | 'world'
+    // プロフィール名 -> リストURIの並び順
+    listOrder?: Record<string, string[]>
 }
 
 export const defaultPreference: Preference = {
     themeName: 'blue',
-    themeVariant: 'classic'
+    themeVariant: 'classic',
+    listOrder: {}
 }
 
 interface PreferenceState {

--- a/app/src/utils/listOrder.ts
+++ b/app/src/utils/listOrder.ts
@@ -1,0 +1,14 @@
+// リストURIの並び順(listOrder)に従って items を並べ替える。
+// order に含まれないもの(新規リスト等)は元の順序を保ったまま末尾に置く。
+export const sortByListOrder = <T extends { uri: string }>(items: T[], order: string[]): T[] => {
+    const rank = new Map(order.map((uri, index) => [uri, index]))
+    return items
+        .map((item, index) => ({ item, index }))
+        .sort((a, b) => {
+            const rankA = rank.get(a.item.uri) ?? Number.POSITIVE_INFINITY
+            const rankB = rank.get(b.item.uri) ?? Number.POSITIVE_INFINITY
+            if (rankA !== rankB) return rankA - rankB
+            return a.index - b.index
+        })
+        .map(({ item }) => item)
+}

--- a/app/src/views/Home.tsx
+++ b/app/src/views/Home.tsx
@@ -20,6 +20,8 @@ import { CssVar } from '../types/Theme'
 import { ListName } from '../components/ListName'
 import { ProfileEditor } from '../components/ProfileEditor'
 import { useSubscribe } from '../hooks/useSubscribe'
+import { usePreference } from '../contexts/Preference'
+import { sortByListOrder } from '../utils/listOrder'
 
 export const HomeView = (props: ScrollViewProps) => {
     const { client } = useClient()
@@ -98,24 +100,28 @@ const HomeMain = ({
     const { client } = useClient()
 
     const [pinnedLists] = useSubscribe(client.pinnedLists)
+    const [listOrder] = usePreference('listOrder')
 
-    const pin = pinnedLists.find((pin) => pin.uri === selectedTabUri)
+    const order = listOrder?.[client.currentProfile] ?? []
+    const sortedPins = sortByListOrder(pinnedLists, order)
+
+    const pin = sortedPins.find((pin) => pin.uri === selectedTabUri)
 
     useEffect(() => {
-        if (selectedTabUri === '' && pinnedLists.length > 0) {
-            setSelectedTabUri(pinnedLists[0].uri)
+        if (selectedTabUri === '' && sortedPins.length > 0) {
+            setSelectedTabUri(sortedPins[0].uri)
         }
     }, [selectedTabUri])
 
     return (
         <>
-            {pinnedLists.length > 1 && (
+            {sortedPins.length > 1 && (
                 <Tabs
                     style={{
                         color: CssVar.contentLink
                     }}
                 >
-                    {pinnedLists.map((tab) => (
+                    {sortedPins.map((tab) => (
                         <Tab
                             key={tab.uri}
                             selected={selectedTabUri === tab.uri}

--- a/app/src/views/Lists.tsx
+++ b/app/src/views/Lists.tsx
@@ -1,10 +1,11 @@
 import { Suspense, use, useMemo, useState } from 'react'
+import { Reorder, useDragControls, motion } from 'motion/react'
 import { Header } from '../ui/Header'
-import { View, Text, IconButton, Button, TextField, List, ListItem } from '@concrnt/ui'
+import { View, Text, IconButton, Button, TextField } from '@concrnt/ui'
 import { useClient } from '../contexts/Client'
 import { List as ListType, ListSchema, Schemas, semantics } from '@concrnt/worldlib'
 import { Document } from '@concrnt/client'
-import { MdPlaylistAdd } from 'react-icons/md'
+import { MdPlaylistAdd, MdDragHandle } from 'react-icons/md'
 
 import { RiPushpinFill } from 'react-icons/ri'
 import { RiPushpinLine } from 'react-icons/ri'
@@ -13,6 +14,8 @@ import { useDrawer } from '../contexts/Drawer'
 import { FAB } from '../ui/FAB'
 import { CssVar } from '../types/Theme'
 import { useSubscribe } from '../hooks/useSubscribe'
+import { usePreference } from '../contexts/Preference'
+import { sortByListOrder } from '../utils/listOrder'
 
 export const ListsView = () => {
     const { client } = useClient()
@@ -33,8 +36,11 @@ export const ListsView = () => {
         <>
             <View>
                 <Header>Lists</Header>
-                <div
+                <motion.div
+                    layoutScroll
                     style={{
+                        flex: 1,
+                        minHeight: 0,
                         overflowY: 'auto'
                     }}
                 >
@@ -46,7 +52,7 @@ export const ListsView = () => {
                             }}
                         />
                     </Suspense>
-                </div>
+                </motion.div>
             </View>
             <FAB
                 onClick={() => {
@@ -73,52 +79,152 @@ interface ListsProps {
 
 const Lists = (props: ListsProps) => {
     const lists = use(props.listsPromise)
-    const drawer = useDrawer()
 
     const { client } = useClient()
 
     const [pinnedLists] = useSubscribe(client.pinnedLists)
+    const [listOrder, setListOrder] = usePreference('listOrder')
+
+    const profile = client.currentProfile
+    const order = listOrder?.[profile] ?? []
+    // 並び順が未設定のうちは、ホームのタブ順(ピン留め順)を基準にして一覧を並べる
+    const effectiveOrder = order.length > 0 ? order : pinnedLists.map((p) => p.uri)
+
+    const sorted = sortByListOrder(lists, effectiveOrder)
+
+    const [ordered, setOrdered] = useState<ListType[]>(sorted)
+
+    // lists や order が外部で更新されたら並びを同期する(レンダー中の状態調整)
+    const sortedKey = sorted.map((l) => l.uri).join(',')
+    const [prevKey, setPrevKey] = useState(sortedKey)
+    if (sortedKey !== prevKey) {
+        setOrdered(sorted)
+        setPrevKey(sortedKey)
+    }
+
+    const persistOrder = (items: ListType[]) => {
+        setListOrder({ ...(listOrder ?? {}), [profile]: items.map((l) => l.uri) })
+    }
 
     return (
-        <List>
-            {lists.map((list) => (
-                <ListItem
+        <Reorder.Group
+            axis="y"
+            values={ordered}
+            onReorder={setOrdered}
+            style={{ listStyle: 'none', margin: 0, padding: 0, width: '100%' }}
+        >
+            {ordered.map((list) => (
+                <ListRow
                     key={list.uri}
-                    style={{
-                        height: '2rem'
+                    list={list}
+                    pinned={pinnedLists.some((p) => p.uri === list.uri)}
+                    onTogglePin={() => {
+                        if (pinnedLists.some((p) => p.uri === list.uri)) {
+                            client?.removePin(list.uri)
+                        } else {
+                            client?.addPin(list.uri)
+                        }
                     }}
-                    onClick={() =>
-                        drawer.open(
-                            <ListSettings
-                                uri={list.uri}
-                                onComplete={() => {
-                                    drawer.close()
-                                    props.onUpdate?.()
-                                }}
-                            />
-                        )
-                    }
-                    secondaryAction={
-                        <IconButton
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                if (pinnedLists.find((p) => p.uri === list.uri)) {
-                                    // unpin
-                                    client?.removePin(list.uri)
-                                } else {
-                                    // pin
-                                    client?.addPin(list.uri)
-                                }
-                            }}
-                        >
-                            {pinnedLists.find((p) => p.uri === list.uri) ? <RiPushpinFill /> : <RiPushpinLine />}
-                        </IconButton>
-                    }
-                >
-                    <Text>{list.title}</Text>
-                </ListItem>
+                    onPersist={() => persistOrder(ordered)}
+                    onUpdate={props.onUpdate}
+                />
             ))}
-        </List>
+        </Reorder.Group>
+    )
+}
+
+interface ListRowProps {
+    list: ListType
+    pinned: boolean
+    onTogglePin: () => void
+    onPersist: () => void
+    onUpdate?: () => void
+}
+
+const ListRow = ({ list, pinned, onTogglePin, onPersist, onUpdate }: ListRowProps) => {
+    const drawer = useDrawer()
+    const controls = useDragControls()
+    const [dragging, setDragging] = useState(false)
+
+    return (
+        <Reorder.Item
+            value={list}
+            dragListener={false}
+            dragControls={controls}
+            onDragStart={() => setDragging(true)}
+            onDragEnd={() => {
+                setDragging(false)
+                onPersist()
+            }}
+            style={{
+                listStyle: 'none',
+                position: 'relative',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                height: '2rem',
+                width: '100%',
+                boxSizing: 'border-box',
+                padding: `0 ${CssVar.space(2)}`,
+                backgroundColor: dragging ? CssVar.contentBackground : 'transparent'
+            }}
+        >
+            <div
+                onClick={() =>
+                    drawer.open(
+                        <ListSettings
+                            uri={list.uri}
+                            onComplete={() => {
+                                drawer.close()
+                                onUpdate?.()
+                            }}
+                        />
+                    )
+                }
+                style={{
+                    flex: 1,
+                    minWidth: 0,
+                    height: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    cursor: 'pointer',
+                    overflow: 'hidden'
+                }}
+            >
+                <Text>{list.title}</Text>
+            </div>
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    flexShrink: 0,
+                    gap: CssVar.space(1)
+                }}
+            >
+                <IconButton
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        onTogglePin()
+                    }}
+                >
+                    {pinned ? <RiPushpinFill /> : <RiPushpinLine />}
+                </IconButton>
+                <div
+                    onPointerDown={(e) => controls.start(e)}
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        cursor: 'grab',
+                        touchAction: 'none',
+                        color: CssVar.contentText,
+                        padding: CssVar.space(1)
+                    }}
+                >
+                    <MdDragHandle size={20} />
+                </div>
+            </div>
+        </Reorder.Item>
     )
 }
 

--- a/web/src/contexts/Preference.tsx
+++ b/web/src/contexts/Preference.tsx
@@ -6,11 +6,14 @@ import { semantics } from '@concrnt/worldlib'
 export interface Preference {
     themeName: string
     themeVariant: 'classic' | 'world'
+    // プロフィール名 -> リストURIの並び順
+    listOrder?: Record<string, string[]>
 }
 
 export const defaultPreference: Preference = {
     themeName: 'blue',
-    themeVariant: 'classic'
+    themeVariant: 'classic',
+    listOrder: {}
 }
 
 interface PreferenceState {

--- a/web/src/utils/listOrder.ts
+++ b/web/src/utils/listOrder.ts
@@ -1,0 +1,14 @@
+// リストURIの並び順(listOrder)に従って items を並べ替える。
+// order に含まれないもの(新規リスト等)は元の順序を保ったまま末尾に置く。
+export const sortByListOrder = <T extends { uri: string }>(items: T[], order: string[]): T[] => {
+    const rank = new Map(order.map((uri, index) => [uri, index]))
+    return items
+        .map((item, index) => ({ item, index }))
+        .sort((a, b) => {
+            const rankA = rank.get(a.item.uri) ?? Number.POSITIVE_INFINITY
+            const rankB = rank.get(b.item.uri) ?? Number.POSITIVE_INFINITY
+            if (rankA !== rankB) return rankA - rankB
+            return a.index - b.index
+        })
+        .map(({ item }) => item)
+}

--- a/web/src/views/Home.tsx
+++ b/web/src/views/Home.tsx
@@ -17,6 +17,8 @@ import { CssVar } from '../types/Theme'
 import { ListName } from '../components/ListName'
 import { ProfileEditor } from '../components/ProfileEditor'
 import { useSubscribe } from '../hooks/useSubscribe'
+import { usePreference } from '../contexts/Preference'
+import { sortByListOrder } from '../utils/listOrder'
 import { Composer } from '../components/Composer'
 
 export const HomeView = (props: ScrollViewProps) => {
@@ -96,24 +98,28 @@ const HomeMain = ({
     const { client } = useClient()
 
     const [pinnedLists] = useSubscribe(client.pinnedLists)
+    const [listOrder] = usePreference('listOrder')
 
-    const pin = pinnedLists.find((pin) => pin.uri === selectedTabUri)
+    const order = listOrder?.[client.currentProfile] ?? []
+    const sortedPins = sortByListOrder(pinnedLists, order)
+
+    const pin = sortedPins.find((pin) => pin.uri === selectedTabUri)
 
     useEffect(() => {
-        if (selectedTabUri === '' && pinnedLists.length > 0) {
-            setSelectedTabUri(pinnedLists[0].uri)
+        if (selectedTabUri === '' && sortedPins.length > 0) {
+            setSelectedTabUri(sortedPins[0].uri)
         }
     }, [selectedTabUri])
 
     return (
         <>
-            {pinnedLists.length > 1 && (
+            {sortedPins.length > 1 && (
                 <Tabs
                     style={{
                         color: CssVar.contentLink
                     }}
                 >
-                    {pinnedLists.map((tab) => (
+                    {sortedPins.map((tab) => (
                         <Tab
                             key={tab.uri}
                             selected={selectedTabUri === tab.uri}

--- a/web/src/views/Lists.tsx
+++ b/web/src/views/Lists.tsx
@@ -1,9 +1,10 @@
 import { Suspense, use, useMemo, useState } from 'react'
-import { Text, IconButton, Button, TextField, List, ListItem } from '@concrnt/ui'
+import { Reorder, useDragControls, motion } from 'motion/react'
+import { Text, IconButton, Button, TextField } from '@concrnt/ui'
 import { useClient } from '../contexts/Client'
 import { List as ListType, ListSchema, Schemas, semantics } from '@concrnt/worldlib'
 import { Document } from '@concrnt/client'
-import { MdPlaylistAdd } from 'react-icons/md'
+import { MdPlaylistAdd, MdDragHandle } from 'react-icons/md'
 
 import { RiPushpinFill } from 'react-icons/ri'
 import { RiPushpinLine } from 'react-icons/ri'
@@ -13,6 +14,8 @@ import { CssVar } from '../types/Theme'
 import { useSubscribe } from '../hooks/useSubscribe'
 import { View } from '../components/View'
 import { Header } from '../components/Header'
+import { usePreference } from '../contexts/Preference'
+import { sortByListOrder } from '../utils/listOrder'
 
 export const ListsView = () => {
     const { client } = useClient()
@@ -59,8 +62,11 @@ export const ListsView = () => {
                 >
                     Lists
                 </Header>
-                <div
+                <motion.div
+                    layoutScroll
                     style={{
+                        flex: 1,
+                        minHeight: 0,
                         overflowY: 'auto'
                     }}
                 >
@@ -72,7 +78,7 @@ export const ListsView = () => {
                             }}
                         />
                     </Suspense>
-                </div>
+                </motion.div>
             </View>
         </>
     )
@@ -85,52 +91,152 @@ interface ListsProps {
 
 const Lists = (props: ListsProps) => {
     const lists = use(props.listsPromise)
-    const drawer = useDrawer()
 
     const { client } = useClient()
 
     const [pinnedLists] = useSubscribe(client.pinnedLists)
+    const [listOrder, setListOrder] = usePreference('listOrder')
+
+    const profile = client.currentProfile
+    const order = listOrder?.[profile] ?? []
+    // 並び順が未設定のうちは、ホームのタブ順(ピン留め順)を基準にして一覧を並べる
+    const effectiveOrder = order.length > 0 ? order : pinnedLists.map((p) => p.uri)
+
+    const sorted = sortByListOrder(lists, effectiveOrder)
+
+    const [ordered, setOrdered] = useState<ListType[]>(sorted)
+
+    // lists や order が外部で更新されたら並びを同期する(レンダー中の状態調整)
+    const sortedKey = sorted.map((l) => l.uri).join(',')
+    const [prevKey, setPrevKey] = useState(sortedKey)
+    if (sortedKey !== prevKey) {
+        setOrdered(sorted)
+        setPrevKey(sortedKey)
+    }
+
+    const persistOrder = (items: ListType[]) => {
+        setListOrder({ ...(listOrder ?? {}), [profile]: items.map((l) => l.uri) })
+    }
 
     return (
-        <List>
-            {lists.map((list) => (
-                <ListItem
+        <Reorder.Group
+            axis="y"
+            values={ordered}
+            onReorder={setOrdered}
+            style={{ listStyle: 'none', margin: 0, padding: 0, width: '100%' }}
+        >
+            {ordered.map((list) => (
+                <ListRow
                     key={list.uri}
-                    style={{
-                        height: '2rem'
+                    list={list}
+                    pinned={pinnedLists.some((p) => p.uri === list.uri)}
+                    onTogglePin={() => {
+                        if (pinnedLists.some((p) => p.uri === list.uri)) {
+                            client?.removePin(list.uri)
+                        } else {
+                            client?.addPin(list.uri)
+                        }
                     }}
-                    onClick={() =>
-                        drawer.open(
-                            <ListSettings
-                                uri={list.uri}
-                                onComplete={() => {
-                                    drawer.close()
-                                    props.onUpdate?.()
-                                }}
-                            />
-                        )
-                    }
-                    secondaryAction={
-                        <IconButton
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                if (pinnedLists.find((p) => p.uri === list.uri)) {
-                                    // unpin
-                                    client?.removePin(list.uri)
-                                } else {
-                                    // pin
-                                    client?.addPin(list.uri)
-                                }
-                            }}
-                        >
-                            {pinnedLists.find((p) => p.uri === list.uri) ? <RiPushpinFill /> : <RiPushpinLine />}
-                        </IconButton>
-                    }
-                >
-                    <Text>{list.title}</Text>
-                </ListItem>
+                    onPersist={() => persistOrder(ordered)}
+                    onUpdate={props.onUpdate}
+                />
             ))}
-        </List>
+        </Reorder.Group>
+    )
+}
+
+interface ListRowProps {
+    list: ListType
+    pinned: boolean
+    onTogglePin: () => void
+    onPersist: () => void
+    onUpdate?: () => void
+}
+
+const ListRow = ({ list, pinned, onTogglePin, onPersist, onUpdate }: ListRowProps) => {
+    const drawer = useDrawer()
+    const controls = useDragControls()
+    const [dragging, setDragging] = useState(false)
+
+    return (
+        <Reorder.Item
+            value={list}
+            dragListener={false}
+            dragControls={controls}
+            onDragStart={() => setDragging(true)}
+            onDragEnd={() => {
+                setDragging(false)
+                onPersist()
+            }}
+            style={{
+                listStyle: 'none',
+                position: 'relative',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                height: '2rem',
+                width: '100%',
+                boxSizing: 'border-box',
+                padding: `0 ${CssVar.space(2)}`,
+                backgroundColor: dragging ? CssVar.contentBackground : 'transparent'
+            }}
+        >
+            <div
+                onClick={() =>
+                    drawer.open(
+                        <ListSettings
+                            uri={list.uri}
+                            onComplete={() => {
+                                drawer.close()
+                                onUpdate?.()
+                            }}
+                        />
+                    )
+                }
+                style={{
+                    flex: 1,
+                    minWidth: 0,
+                    height: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    cursor: 'pointer',
+                    overflow: 'hidden'
+                }}
+            >
+                <Text>{list.title}</Text>
+            </div>
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    flexShrink: 0,
+                    gap: CssVar.space(1)
+                }}
+            >
+                <IconButton
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        onTogglePin()
+                    }}
+                >
+                    {pinned ? <RiPushpinFill /> : <RiPushpinLine />}
+                </IconButton>
+                <div
+                    onPointerDown={(e) => controls.start(e)}
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        cursor: 'grab',
+                        touchAction: 'none',
+                        color: CssVar.contentText,
+                        padding: CssVar.space(1)
+                    }}
+                >
+                    <MdDragHandle size={20} />
+                </div>
+            </div>
+        </Reorder.Item>
     )
 }
 


### PR DESCRIPTION
resolve #97 

リスト画面でリストを自由に並び替えられるようにしました。並び順はホーム画面のタブ順と共通化され、デバイス間でも同期されます。あわせて、ピン留めの切り替えが効かない不具合も修正しました。
 
## 対応した要件
 
### 1. ハンドルによる並び替え
- ピン留めボタンの右に3本線のドラッグハンドル (`MdDragHandle`) を追加しました。
- `motion/react` の `Reorder` + `useDragControls` を使用しています。`dragListener={false}` でハンドルからのみ掴めるようにし、行本体のタップやスクロールとは干渉しません (`touchAction: 'none'`)。
- ピン留めの有無にかかわらず、すべてのリストを並び替えできます。


### 2. リスト順をホーム画面と一致 
- 並び順を `listOrder` に一本化し、リスト画面・ホーム画面の両方を同じ順序で表示するようにしました。
- 並び順が未設定の初期状態では、ピン留め順 (= ホームのタブ順) を基準にフォールバックするため、最初から両画面の順序が一致します。


### 3. ピン留めトグルの修正 
- 行のタップ領域をリスト名部分のみに限定し、ピン留めボタンとドラッグハンドルを独立した領域に分離しました。
- これにより、トグルのタップがメインのタップ領域 (設定を開く操作) に吸われてしまい、ピン留めの切り替えが反応しなかった問題を解消しています。


## 設計上の判断 (レビュー観点) 
**並び順は新しいスキーマを追加せず、`Preference` (settings ドキュメント) に `listOrder` フィールドとして保存しています。**
 
- 理由: 新規スキーマを `schema.concrnt.world` に公開する手間を避けつつ、`Preference` が既に備えている「ローカル保存 + サーバ同期」の仕組みに乗せることで、デバイス間同期を無料で得られるためです。
- 形式は `Record<profileName, string[]>` (プロフィール名 → リストURIの並び順) です。リストはプロフィール単位で管理されているため、並び順もプロフィール別に保持しています。


## 実装メモ 
- `Reorder.Item` に `position: relative` を指定しています。motion がドラッグ中の要素に付与する z-index は、`position` が `static` 以外でないと効かないためです。
- スクロール領域に `flex: 1, minHeight: 0` を指定しています。これが無いとコンテナの高さが中身ぴったりになり、ドラッグした行が `overflow` の境界でクリップされて見えなくなります。
- 並び順に存在しないリスト (新規作成直後など) は、元の順序を保ったまま末尾に配置します (`sortByListOrder`)。


## 変更ファイル 
- `app|web/src/contexts/Preference.tsx` — `Preference` に `listOrder?: Record<string, string[]>` を追加
- `app|web/src/utils/listOrder.ts` — 並び順ソートの共通ヘルパ (新規)
- `app|web/src/views/Lists.tsx` — Reorder による並び替え、ハンドル、トグル修正、スクロール領域の修正
- `app|web/src/views/Home.tsx` — タブを `listOrder` 順にソート


## 動作確認
- ハンドルでの並び替え、並び順の永続化、アプリ再起動後の保持
- ホームのタブ順とリスト画面の順序が一致すること
- ピン留め / 解除トグルの動作
- 未ピンのリストも並び替えできること