### PR TITLE
投稿元アカウントの切り替え機能を実装しました

### DIFF
--- a/app/src/components/Composer.tsx
+++ b/app/src/components/Composer.tsx
@@ -43,6 +43,7 @@ export const Composer = (props: Props) => {
     const [willClose, setWillClose] = useState<boolean>(false)
     const [draft, setDraft] = useState<string>(props.draftBuffer?.draftText ?? '')
     const [postHome, setPostHome] = useState<boolean>(props.draftBuffer?.postHome ?? true)
+    const [selectedProfile, setSelectedProfile] = useState<string>(client?.currentProfile ?? 'main')
     const [mediaDrafts, setMediaDrafts] = useState<MediaDraft[]>(() => {
         if (!props.draftBuffer || props.draftBuffer.mediaDrafts.length === 0) return []
         return props.draftBuffer.mediaDrafts.map((m) => ({
@@ -135,14 +136,14 @@ export const Composer = (props: Props) => {
     const handleSubmit = async () => {
         if (!client) return
 
-        const homeTimeline = semantics.homeTimeline(client.ccid, client.currentProfile)
-        const activityTimeline = semantics.activityTimeline(client.ccid, client.currentProfile)
+        const homeTimeline = semantics.homeTimeline(client.ccid, selectedProfile)
+        const activityTimeline = semantics.activityTimeline(client.ccid, selectedProfile)
         const distributes = [...(postHome ? [homeTimeline] : []), ...props.destinations]
 
         const timestamp = new Date()
         const hash = CDID.newFromString(draft, timestamp).toString()
 
-        const newPostUri = semantics.post(client.ccid, client.currentProfile, hash)
+        const newPostUri = semantics.post(client.ccid, selectedProfile, hash)
 
         let success = false
         try {
@@ -615,6 +616,8 @@ export const Composer = (props: Props) => {
                                     labelFunc={(item: Timeline) => item.name}
                                     postHome={postHome}
                                     setPostHome={setPostHome}
+                                    selectedProfile={selectedProfile}
+                                    setSelectedProfile={setSelectedProfile}
                                 />
                             </div>
 

--- a/app/src/components/TimelinePicker.tsx
+++ b/app/src/components/TimelinePicker.tsx
@@ -7,9 +7,11 @@ import { IoMdCloseCircle } from 'react-icons/io'
 import { IoMdAdd } from 'react-icons/io'
 
 import { useClient } from '../contexts/Client'
-import { Avatar } from '@concrnt/ui'
+import { Avatar, ListItem } from '@concrnt/ui'
 import { CssVar } from '../types/Theme'
 import { hapticSelection } from '../utils/haptics'
+import { useSelect } from '../contexts/Select'
+import { ProfileName } from './ProfileName'
 
 interface Props {
     selected: string[]
@@ -19,10 +21,13 @@ interface Props {
     labelFunc: (item: any) => string
     postHome?: boolean
     setPostHome?: (postHome: boolean) => void
+    selectedProfile?: string
+    setSelectedProfile?: (profile: string) => void
 }
 
 export const TimelinePicker = (props: Props) => {
     const { client } = useClient()
+    const { select, close } = useSelect()
 
     const [focused, setFocused] = useState(false)
     const [focusedIdx, setFocusedIdx] = useState<number>(0)
@@ -37,6 +42,43 @@ export const TimelinePicker = (props: Props) => {
         return remains.filter((i) => props.labelFunc(i).toLowerCase().includes(filter.toLowerCase()))
     }, [props, filter])
 
+    // 投稿元プロフィール（未指定時はクライアントのcurrentProfileにフォールバック）
+    const activeProfile = props.selectedProfile ?? client?.currentProfile ?? 'main'
+    const activeProfileDoc = client?.profiles?.[activeProfile]
+    const profileAvatar = activeProfileDoc?.value.avatar ?? client?.profile.avatar
+    const profileUsername = activeProfileDoc?.value.username ?? client?.profile.username ?? 'Home'
+
+    const openProfileSelect = () => {
+        if (!client) return
+        const profileOptions = Object.entries(client.profiles).map(([key, profile]) => (
+            <ListItem
+                key={key}
+                icon={
+                    <Avatar
+                        ccid={profile.author}
+                        src={profile.value.avatar}
+                        style={{ width: '32px', height: '32px' }}
+                    />
+                }
+                onClick={() => {
+                    props.setSelectedProfile?.(key)
+                    close()
+                }}
+            >
+                <div
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        paddingLeft: CssVar.space(2)
+                    }}
+                >
+                    <ProfileName document={profile} />
+                </div>
+            </ListItem>
+        ))
+        select('投稿元プロフィール', profileOptions)
+    }
+
     return (
         <div
             style={{
@@ -48,10 +90,15 @@ export const TimelinePicker = (props: Props) => {
             }}
         >
             <Chip
+                onClick={() => {
+                    if (!props.setSelectedProfile) return
+                    hapticSelection()
+                    openProfileSelect()
+                }}
                 headElement={
                     <Avatar
                         ccid={client?.ccid ?? ''}
-                        src={client?.profile.avatar}
+                        src={profileAvatar}
                         style={{
                             width: 20,
                             height: 20
@@ -76,7 +123,7 @@ export const TimelinePicker = (props: Props) => {
                     opacity: props.postHome === false ? 0.5 : 1
                 }}
             >
-                {client?.profile.username ?? 'Home'}
+                {profileUsername}
             </Chip>
             {props.selected.map((sel) => {
                 const item = props.items.find((i) => props.keyFunc(i) === sel)

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -43,6 +43,7 @@ export const Composer = (props: Props) => {
     const [willClose, setWillClose] = useState<boolean>(false)
     const [draft, setDraft] = useState<string>(props.draftBuffer?.draftText ?? '')
     const [postHome, setPostHome] = useState<boolean>(props.draftBuffer?.postHome ?? true)
+    const [selectedProfile, setSelectedProfile] = useState<string>(client?.currentProfile ?? 'main')
     const [mediaDrafts, setMediaDrafts] = useState<MediaDraft[]>(() => {
         if (!props.draftBuffer || props.draftBuffer.mediaDrafts.length === 0) return []
         return props.draftBuffer.mediaDrafts.map((m) => ({
@@ -135,14 +136,14 @@ export const Composer = (props: Props) => {
     const handleSubmit = async () => {
         if (!client) return
 
-        const homeTimeline = semantics.homeTimeline(client.ccid, client.currentProfile)
-        const activityTimeline = semantics.activityTimeline(client.ccid, client.currentProfile)
+        const homeTimeline = semantics.homeTimeline(client.ccid, selectedProfile)
+        const activityTimeline = semantics.activityTimeline(client.ccid, selectedProfile)
         const distributes = [...(postHome ? [homeTimeline] : []), ...props.destinations]
 
         const timestamp = new Date()
         const hash = CDID.newFromString(draft, timestamp).toString()
 
-        const newPostUri = semantics.post(client.ccid, client.currentProfile, hash)
+        const newPostUri = semantics.post(client.ccid, selectedProfile, hash)
 
         let success = false
         try {
@@ -627,6 +628,8 @@ export const Composer = (props: Props) => {
                                     labelFunc={(item: Timeline) => item.name}
                                     postHome={postHome}
                                     setPostHome={setPostHome}
+                                    selectedProfile={selectedProfile}
+                                    setSelectedProfile={setSelectedProfile}
                                 />
                             </div>
 

--- a/web/src/components/TimelinePicker.tsx
+++ b/web/src/components/TimelinePicker.tsx
@@ -7,9 +7,11 @@ import { IoMdCloseCircle } from 'react-icons/io'
 import { IoMdAdd } from 'react-icons/io'
 
 import { useClient } from '../contexts/Client'
-import { Avatar } from '@concrnt/ui'
+import { Avatar, ListItem } from '@concrnt/ui'
 import { CssVar } from '../types/Theme'
 import { hapticSelection } from '../utils/haptics'
+import { useSelect } from '../contexts/Select'
+import { ProfileName } from './ProfileName'
 
 interface Props {
     selected: string[]
@@ -19,10 +21,13 @@ interface Props {
     labelFunc: (item: any) => string
     postHome?: boolean
     setPostHome?: (postHome: boolean) => void
+    selectedProfile?: string
+    setSelectedProfile?: (profile: string) => void
 }
 
 export const TimelinePicker = (props: Props) => {
     const { client } = useClient()
+    const { select, close } = useSelect()
 
     const [focused, setFocused] = useState(false)
     const [focusedIdx, setFocusedIdx] = useState<number>(0)
@@ -37,6 +42,43 @@ export const TimelinePicker = (props: Props) => {
         return remains.filter((i) => props.labelFunc(i).toLowerCase().includes(filter.toLowerCase()))
     }, [props, filter])
 
+    // 投稿元プロフィール（未指定時はクライアントのcurrentProfileにフォールバック）
+    const activeProfile = props.selectedProfile ?? client?.currentProfile ?? 'main'
+    const activeProfileDoc = client?.profiles?.[activeProfile]
+    const profileAvatar = activeProfileDoc?.value.avatar ?? client?.profile.avatar
+    const profileUsername = activeProfileDoc?.value.username ?? client?.profile.username ?? 'Home'
+
+    const openProfileSelect = () => {
+        if (!client) return
+        const profileOptions = Object.entries(client.profiles).map(([key, profile]) => (
+            <ListItem
+                key={key}
+                icon={
+                    <Avatar
+                        ccid={profile.author}
+                        src={profile.value.avatar}
+                        style={{ width: '32px', height: '32px' }}
+                    />
+                }
+                onClick={() => {
+                    props.setSelectedProfile?.(key)
+                    close()
+                }}
+            >
+                <div
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        paddingLeft: CssVar.space(2)
+                    }}
+                >
+                    <ProfileName document={profile} />
+                </div>
+            </ListItem>
+        ))
+        select('投稿元プロフィール', profileOptions)
+    }
+
     return (
         <div
             style={{
@@ -48,10 +90,15 @@ export const TimelinePicker = (props: Props) => {
             }}
         >
             <Chip
+                onClick={() => {
+                    if (!props.setSelectedProfile) return
+                    hapticSelection()
+                    openProfileSelect()
+                }}
                 headElement={
                     <Avatar
                         ccid={client?.ccid ?? ''}
-                        src={client?.profile.avatar}
+                        src={profileAvatar}
                         style={{
                             width: 20,
                             height: 20
@@ -76,7 +123,7 @@ export const TimelinePicker = (props: Props) => {
                     opacity: props.postHome === false ? 0.5 : 1
                 }}
             >
-                {client?.profile.username ?? 'Home'}
+                {profileUsername}
             </Chip>
             {props.selected.map((sel) => {
                 const item = props.items.find((i) => props.keyFunc(i) === sel)


### PR DESCRIPTION
resolve #107 

旧 Concrnt アプリの「投稿先アイコンをタップしてサブプロフィールを選択」する挙動を、新アーキテクチャ（プロフィール単位の URI namespace）に合わせて再実装しています。

## 変更点
- `TimelinePicker` にホームプロフィール選択メニューを追加
  - ホーム Chip タップで `useSelect`（SwitchAccountButton と同じボトムシート）を開き、`client.profiles` 一覧から投稿元を選択
  - Chip のアイコン/ユーザー名は選択中プロフィールに追従
- `Composer` の投稿処理で、`homeTimeline` / `activityTimeline` / 投稿 URI の profile 引数を選択中プロフィールに差し替え
- 通常投稿・リプライ・リルートの全モードで有効

## 設計メモ
- 新モデルではプロフィールは URI namespace（`profiles/{profile}/...`）で表現されるため、旧アプリの `profileOverride` フィールドは使わず、semantics の profile 引数のみ差し替える方針。
- association の作成構造・通知ディスパッチ（`notifyTimeline`）には手を入れていません。
- 投稿先候補（コミュニティ/リスト）は currentProfile 由来のまま（旧アプリと同挙動）。
- 作成直後で未切り替えのサブプロフィールへの投稿可否は @totogamma に確認済み（問題なし）。

## 既知の制限
- 選択した投稿元は composer を閉じると初期化される（DraftBuffer 非保持）。
- インライン版 composer には TimelinePicker が無いため投稿元選択は出ない（既存仕様）。